### PR TITLE
ModbusSparseDataBlock handled dictionaries incorrectly (they have an __i...

### DIFF
--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -199,7 +199,7 @@ class ModbusSparseDataBlock(BaseModbusDataBlock):
         '''
         if isinstance(values, dict):
             self.values = values
-        if hasattr(values, '__iter__'):
+        elif hasattr(values, '__iter__'):
             self.values = dict(enumerate(values))
         else: raise ParameterException(
             "Values for datastore must be a list or dictionary")


### PR DESCRIPTION
...ter__ attribute). Changed 'if' to 'elif'
