### PR TITLE
Fix bogus calculation in ModbusSocketFramer.checkFrame

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -182,7 +182,7 @@ class ModbusSocketFramer(IModbusFramer):
             if self.__header['len'] < 2:
                 self.advanceFrame()
             # we have at least a complete message, continue
-            elif len(self.__buffer) >= self.__header['len']:
+            elif len(self.__buffer) - self.__hsize + 1 >= self.__header['len']:
                 return True
         # we don't have enough of a message yet, wait
         return False

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -10,9 +10,9 @@ class ModbusTransactionTest(unittest.TestCase):
     This is the unittest for the pymodbus.transaction module
     '''
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # Test Construction
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def setUp(self):
         ''' Sets up the test environment '''
         self.decoder  = ServerDecoder()
@@ -24,14 +24,14 @@ class ModbusTransactionTest(unittest.TestCase):
 
     def tearDown(self):
         ''' Cleans up the test environment '''
-        del self._manager    
-        del self._tcp        
-        del self._rtu        
-        del self._ascii      
+        del self._manager
+        del self._tcp
+        del self._rtu
+        del self._ascii
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # Other Class tests
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def testModbusTransactionManagerTID(self):
         ''' Test the tcp transaction manager TID '''
         for tid in range(1, self._manager.getNextTID() + 10):
@@ -62,9 +62,9 @@ class ModbusTransactionTest(unittest.TestCase):
         self._manager.delTransaction(handle.transaction_id)
         self.assertEqual(None, self._manager.getTransaction(handle.transaction_id))
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # TCP tests
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def testTCPFramerTransactionReady(self):
         ''' Test a tcp frame transaction '''
         msg = "\x00\x01\x12\x34\x00\x04\xff\x02\x12\x34"
@@ -115,10 +115,24 @@ class ModbusTransactionTest(unittest.TestCase):
         self.assertEqual(msg2, result)
         self._tcp.advanceFrame()
 
+    def testTCPFramerTransactionHalf3(self):
+        ''' Test a half completed tcp frame transaction '''
+        msg1 = "\x00\x01\x12\x34\x00\x04\xff\x02\x12"
+        msg2 = "\x34"
+        self._tcp.addToFrame(msg1)
+        self.assertFalse(self._tcp.checkFrame())
+        result = self._tcp.getFrame()
+        self.assertEqual(msg1[7:], result)
+        self._tcp.addToFrame(msg2)
+        self.assertTrue(self._tcp.checkFrame())
+        result = self._tcp.getFrame()
+        self.assertEqual(msg1[7:] + msg2, result)
+        self._tcp.advanceFrame()
+
     def testTCPFramerTransactionShort(self):
         ''' Test that we can get back on track after an invalid message '''
         msg1 = "\x99\x99\x99\x99\x00\x01\x00\x01"
-        msg2 = "\x00\x01\x12\x34\x00\x05\xff\x02\x12\x34"
+        msg2 = "\x00\x01\x12\x34\x00\x04\xff\x02\x12\x34"
         self._tcp.addToFrame(msg1)
         self.assertFalse(self._tcp.checkFrame())
         result = self._tcp.getFrame()
@@ -160,9 +174,9 @@ class ModbusTransactionTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         ModbusRequest.encode = old_encode
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # RTU tests
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def testRTUFramerTransactionReady(self):
         ''' Test if the checks for a complete frame work '''
         self.assertFalse(self._rtu.isFrameReady())
@@ -233,9 +247,9 @@ class ModbusTransactionTest(unittest.TestCase):
         result = self._rtu.checkFrame()
         self.assertTrue(result)
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # ASCII tests
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def testASCIIFramerTransactionReady(self):
         ''' Test a ascii frame transaction '''
         msg = ':F7031389000A60\r\n'
@@ -292,9 +306,9 @@ class ModbusTransactionTest(unittest.TestCase):
         self.assertEqual(expected, actual)
         ModbusRequest.encode = old_encode
 
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     # Binary tests
-    #---------------------------------------------------------------------------# 
+    #---------------------------------------------------------------------------#
     def testBinaryFramerTransactionReady(self):
         ''' Test a binary frame transaction '''
         msg  = '\x7b\x01\x03\x00\x00\x00\x05\x85\xC9\x7d'


### PR DESCRIPTION
I found out a bug in the checkFrame() logic: the packet size calculation is inconsistent with getFrame() and advanceFrame().
