### PR TITLE
Fixing serial RTU server behavior 

### DIFF
--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -218,8 +218,7 @@ class ModbusTransactionTest(unittest.TestCase):
 
         msg_parts = ["\x00\x01\x00", "\x00\x00\x01\xfc\x1b"]
         self._rtu.addToFrame(msg_parts[0])
-        self.assertTrue(self._rtu.isFrameReady())
-        self.assertFalse(self._rtu.checkFrame())
+        self.assertFalse(self._rtu.isFrameReady())
 
         self._rtu.addToFrame(msg_parts[1])
         self.assertTrue(self._rtu.isFrameReady())


### PR DESCRIPTION
This is a fix on RTUFramer to avoid misleading buffer RESET when processing unfinished requests.
The patch modifies isFrameReady(), introducing (reusing) a minimal package size threshold (8 bytes) check and then uses the corresponding PDU processor to calculate the entire request size it should wait for before processing.
In practical terms, it avoids the unreliable time-dependent wait (3.5 bytes) for the end-of-frame.
