### PR TITLE
 Fixed docstring in synchronous serial client connect() method

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -310,7 +310,7 @@ class ModbusSerialClient(BaseModbusClient):
         raise ParameterException("Invalid framer method requested")
 
     def connect(self):
-        ''' Connect to the modbus tcp server
+        ''' Connect to the modbus serial server
 
         :returns: True if connection succeeded, False otherwise
         '''


### PR DESCRIPTION
I think there was a copy/paste error in the docstring. It said tcp but I think it is supposed to be serial.
