### PR TITLE
Add 'ignore_undefined_slaves' to synchronous ModbusSerialServer

### DIFF
--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -89,6 +89,7 @@ class Defaults(Singleton):
     Parity        = 'N'
     Bytesize      = 8
     Stopbits      = 1
+    ignore_undefined_slaves = False
 
 
 class ModbusStatus(Singleton):


### PR DESCRIPTION
The default behaviour of pymodbus is to return an error to all messages addressed to a slave unit that is not defined in the given server context. An option exists for responding to all slave IDs with a single context, but not to ignore messages to any undefined slave ID.

This creates a problem when pymodbus is sharing a bus with other units, as it sends error messages clobbering the proper responses from the rightful addressees.

This patch adds an ignore_undefined_slaves boolean parameter to the synchronous ModbusSerialServer. For compatibility with older programs, default has been left to False.

For now, the option is only on the synchronous serial server, as it's the one I needed. If the patch is accepted, I'll be happy to add this option also to the IP based servers and all async servers.
