### PR TITLE
logging added

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -529,6 +529,7 @@ class ModbusRtuFramer(IModbusFramer):
         :param data: The new packet data
         :param callback: The function to send results to
         '''
+       _logger.debug("IN:"+" ".join([hex(ord(x)) for x in data]))
         self.addToFrame(data)
         while self.isFrameReady():
             if self.checkFrame():
@@ -550,6 +551,7 @@ class ModbusRtuFramer(IModbusFramer):
             message.unit_id,
             message.function_code) + data
         packet += struct.pack(">H", computeCRC(packet))
+        _logger.debug("OUT:"+" ".join([hex(ord(x)) for x in packet]))
         return packet
 
 
@@ -673,6 +675,7 @@ class ModbusAsciiFramer(IModbusFramer):
         :param data: The new packet data
         :param callback: The function to send results to
         '''
+       _logger.debug(" ".join([hex(ord(x)) for x in data]))
         self.addToFrame(data)
         while self.isFrameReady():
             if self.checkFrame():
@@ -829,6 +832,7 @@ class ModbusBinaryFramer(IModbusFramer):
         :param data: The new packet data
         :param callback: The function to send results to
         '''
+       _logger.debug(" ".join([hex(ord(x)) for x in data]))
         self.addToFrame(data)
         while self.isFrameReady():
             if self.checkFrame():


### PR DESCRIPTION
Extra logging of incoming and outgoing packets added
to ModbusRtuFramer.processIncomingPacket and builtPacket.

Also added logging of incoming packets to:
   ModbusAsciiFrammer.processIncomingPacket
   ModbusBinaryFrammer.processIncomingPacket
Above makes them consistent with ModbusSocketFramer.
