### PR TITLE
add unit id for query

### DIFF
--- a/examples/asynchronous-client-with-unit-id.py
+++ b/examples/asynchronous-client-with-unit-id.py
@@ -1,0 +1,4 @@
+import pymodbus.client.sync import ModbusTcpClient
+client = ModbusTcpClient('192.168.0.107')
+res = client.read_holding_registers(3999, 24, unit=2)
+print res.registers


### PR DESCRIPTION
A simple example for modbus/tcp query with unit id or slave id
