### PR TITLE
PATCH: boost serial speed 3x or more

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -304,6 +304,8 @@ class ModbusSerialClient(BaseModbusClient):
         self.parity   = kwargs.get('parity',   Defaults.Parity)
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout  = kwargs.get('timeout',  Defaults.Timeout)
+        self._last_frame_end = 0.0
+        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
 
     @staticmethod
     def __implementation(method):
@@ -333,7 +335,6 @@ class ModbusSerialClient(BaseModbusClient):
             _logger.error(msg)
             self.close()
         self._last_frame_end = time.time()
-        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
         return self.socket != None
 
     def close(self):

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -1,5 +1,6 @@
 import socket
 import serial
+import time
 
 from pymodbus.constants import Defaults
 from pymodbus.factory import ClientDecoder
@@ -331,6 +332,8 @@ class ModbusSerialClient(BaseModbusClient):
         except serial.SerialException, msg:
             _logger.error(msg)
             self.close()
+        self._last_frame_end = time.time()
+        self._silent_interval = 3.5 * (1 + 8 + 2) / self.baudrate
         return self.socket != None
 
     def close(self):
@@ -345,12 +348,20 @@ class ModbusSerialClient(BaseModbusClient):
 
         If receive buffer still holds some data then flush it.
 
+        Sleep if last send finished less than 3.5 character
+        times ago.
+
         :param request: The encoded request to send
         :return: The number of bytes written
         '''
         if not self.socket:
             raise ConnectionException(self.__str__())
         if request:
+            ts = time.time()
+            if ts < self._last_frame_end + self._silent_interval:
+                _logger.debug("will sleep to wait for 3.5 char")
+                time.sleep(self._last_frame_end + self._silent_interval - ts)
+
             try:
                 waitingbytes = self.socket.inWaiting()
                 if waitingbytes:
@@ -360,7 +371,9 @@ class ModbusSerialClient(BaseModbusClient):
             except NotImplementedError:
                 pass
 
-            return self.socket.write(request)
+            size = self.socket.write(request)
+            self._last_frame_end = time.time()
+            return size
         return 0
 
     def _recv(self, size):
@@ -371,7 +384,9 @@ class ModbusSerialClient(BaseModbusClient):
         '''
         if not self.socket:
             raise ConnectionException(self.__str__())
-        return self.socket.read(size)
+        result = self.socket.read(size)
+        self._last_frame_end = time.time()
+        return result
 
     def __str__(self):
         ''' Builds a string representation of the connection

--- a/pymodbus/interfaces.py
+++ b/pymodbus/interfaces.py
@@ -151,6 +151,14 @@ class IModbusFramer(object):
         raise NotImplementedException(
             "Method not implemented by derived class")
 
+    def getResponseSize(self, message):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        raise NotImplementedException(
+            "Method not implemented by derived class")
+
 
 class IModbusSlaveContext(object):
     '''

--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -106,6 +106,13 @@ class ModbusRequest(ModbusPDU):
                 (self.function_code, exception))
         return ExceptionResponse(self.function_code, exception)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :raises: A not implemented exception
+        '''
+        raise NotImplementedException()
+
 
 class ModbusResponse(ModbusPDU):
     ''' Base class for a modbus response PDU

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -38,6 +38,13 @@ class ReadRegistersRequestBase(ModbusRequest):
         '''
         self.address, self.count = struct.unpack('>HH', data)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 1 + 2 * self.count
+
     def __str__(self):
         ''' Returns a string representation of the instance
 

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -188,6 +188,13 @@ class WriteMultipleRegistersRequest(ModbusRequest):
         context.setValues(self.function_code, self.address, self.values)
         return WriteMultipleRegistersResponse(self.address, self.count)
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 2 + 2
+
     def __str__(self):
         ''' Returns a string representation of the instance
 

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -61,6 +61,13 @@ class WriteSingleRegisterRequest(ModbusRequest):
         values = context.getValues(self.function_code, self.address, 1)
         return WriteSingleRegisterResponse(self.address, values[0])
 
+    def getResponseSize(self):
+        ''' Returns expected packet size of response for this request
+
+        :returns: The expected packet size
+        '''
+        return 2 + 2
+
     def __str__(self):
         ''' Returns a string representation of the instance
 


### PR DESCRIPTION
pymodbus over serial port is slow. The reason is that once serial port is opened, the initial timeout values is an indication how long it takes to get Modbus response. If one knows exactly how long it takes for controller to respond to the request, it is possible to manually tune timeout with quite good precision. But when different requests are used where responses have different latency and different length, then timeout should be set based on the slowest response. Otherwise some data just remains in buffer and both this and next response will be incorrect.

To overcome this, we need to get rid of timer and know how big is the response of any request. When ModbusSerialClient reads the response, it should know how many bytes to read and not wait for any timeout. For that I implemented getResponseSize() method in ModbusRequest class (and its derived classes). If response size is known, then ModbusTransactionManager.execute() reads only this amount of bytes. If size is not known, then the old timeout based behavior is used. Latter happens also with exception responses which are usually shorter than full response frames. Because most operations do not depend on timeout any more, much longer timeout can be used.

This is implemented only for ModbusRtuFramer and serial port right now.

Using this technique alone could cause a new kind of problem: the next request might happen too quickly after previous one. Modbus standard requires that there is silent interval of at least 3.5 character times between message serial RTU frames. For that _silentinterval is calculated based on serial port baud rate in ModbusSerialClient.connect(), and serial port write times are always saved to the _lastsend variable. Before every send it is checked that there has been at least _silentinterval delay between consecutive requests. However, I'm not sure if serial port writes are always synchronous. This may need some more work if not.

I also added serial port input buffer flushing before sending request. This makes sure that any old or incorrect data can't mess up with the next response.

Some words about performance. I'm testing with Modbus RTU slave at 19200 bps. This controller responds to holding register reads usually within 0.4 … 14 ms. However sometimes the response takes around 20 ms. 7 byte response for one holding register request takes 4.5 ms. So, the minimum timeout that can be used should be at least 25 ms if only such requests are used. And results are:

pymodbus with timeout: 24…26 req/sec
pymodbus with getResponseSize(): 76…78 req/sec

Enjoy,
## 

Cougar
