### PR TITLE
ReportSlaveId: use correct slaveid/additional data

### DIFF
--- a/test/test_other_messages.py
+++ b/test/test_other_messages.py
@@ -90,15 +90,20 @@ class ModbusOtherMessageTest(unittest.TestCase):
         request.decode('\x12')
         self.assertEqual(request.encode(), '')
         self.assertEqual(request.execute().function_code, 0x11)
-
-        response = ReportSlaveIdResponse(request.execute().identifier, True)
-        self.assertEqual(response.encode(), '\x0apymodbus\xff')
+        req = request.execute()
+        response = ReportSlaveIdResponse(req.identifier, True, req.extra_data)
+        self.assertEqual(response.encode(), '\x0a\x55\xffpymodbus')
         response.decode('\x03\x12\x00')
         self.assertEqual(response.status, False)
-        self.assertEqual(response.identifier, '\x12\x00')
+        self.assertEqual(response.identifier, '\x12')
 
         response.status = False
-        self.assertEqual(response.encode(), '\x04\x12\x00\x00')
+        self.assertEqual('\x02\x12\x00', response.encode())
+
+        response.decode('\x07\x05\xffmagic')
+        self.assertEqual(True, response.status)
+        self.assertEqual('\x05', response.identifier)
+        self.assertEqual("magic", response.extra_data)
 
 #---------------------------------------------------------------------------#
 # Main


### PR DESCRIPTION
The Modbus application spec isn't very clear, but the "slave id" field
in ReportSlaveId response is a single byte, then the single byte of
0x00/0xff for status, _then_ the trailing arbitrary data.  Likewise,
the byte count doesn't include either slave id field.

Further, the standard code was passing an extra argument to the execute
method, so it wasn't even getting as far as doing the wrong thing
normally.

This behaviour verified against a Frer and Schneider real world power
meters, and also the behaviour of libmodbus for the length.

Signed-off-by: Karl Palsson karlp@remake.is

(Notes: I don't know the appropriate way of validating that the identifier as passed is only a single byte)
