### PR TITLE
Asyncio client support for python 3 branch

### DIFF
--- a/pymodbus/client/async_asyncio.py
+++ b/pymodbus/client/async_asyncio.py
@@ -1,0 +1,133 @@
+"""Asynchronous framework adapter for asyncio."""
+import asyncio
+from pymodbus.client.async_common import AsyncModbusClientMixin
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+class ModbusClientProtocol(asyncio.Protocol, AsyncModbusClientMixin):
+    """Asyncio specific implementation of asynchronous modubus client protocol."""
+
+    #: Factory that created this instance.
+    factory = None
+
+    def connection_made(self, transport):
+        self.transport = transport
+        self._connectionMade()
+
+        if self.factory:
+            self.factory.protocol_made_connection(self)
+
+    def connection_lost(self, reason):
+        self.transport = None
+        self._connectionLost(reason)
+
+        if self.factory:
+            self.factory.protocol_lost_connection(self)
+
+    def data_received(self, data):
+        self._dataReceived(data)
+
+    def create_future(self):
+        return asyncio.Future()
+
+    def resolve_future(self, f, result):
+        f.set_result(result)
+
+    def raise_future(self, f, exc):
+        f.set_exception(exc)
+
+
+class ReconnectingAsyncioModbusTcpClient(object):
+    """Client to connect to modbus device repeatedly over TCP/IP."""
+
+    #: Reconnect delay in milli seconds.
+    delay_ms = 0
+
+    #: Maximum delay in milli seconds before reconnect is attempted.
+    DELAY_MAX_MS = 1000 * 60 * 5
+
+    def __init__(self, protocol_class=None, loop=None):
+        #: Protocol used to talk to modbus device.
+        self.protocol_class = protocol_class or ModbusClientProtocol
+        #: Current protocol instance.
+        self.protocol = None
+        #: Event loop to use.
+        self.loop = loop or asyncio.get_event_loop()
+
+        self.host = None
+        self.port = 0
+
+        self.connected = False
+        self.reset_delay()
+
+    def reset_delay(self):
+        """Resets wait before next reconnect to minimal period."""
+        self.delay_ms = 100
+
+    @asyncio.coroutine
+    def start(self, host, port=502):
+        # force reconnect if required:
+        self.stop()
+
+        _logger.debug('Connecting to %s:%s.' % (host, port))
+        self.host = host
+        self.port = port
+
+        yield from self._connect()
+
+    def stop(self):
+        # prevent reconnect:
+        self.host = None
+
+        if self.connected:
+            if self.protocol:
+                if self.protocol.transport:
+                    self.protocol.transport.close()
+
+    def _create_protocol(self):
+        """Factory function to create initialized protocol instance."""
+        protocol = self.protocol_class()
+        protocol.factory = self
+        return protocol
+
+    @asyncio.coroutine
+    def _connect(self):
+        _logger.debug('Connecting.')
+        try:
+            yield from self.loop.create_connection(self._create_protocol, self.host, self.port)
+            _logger.info('Connected to %s:%s.' % (self.host, self.port))
+        except Exception as ex:
+            _logger.warning('Failed to connect: %s' % ex)
+            asyncio.async(self._reconnect(), loop=self.loop)
+
+    def protocol_made_connection(self, protocol):
+        """Protocol notification of successful connection."""
+        _logger.info('Protocol made connection.')
+        if not self.connected:
+            self.connected = True
+            self.protocol = protocol
+        else:
+            _logger.error('Factory protocol connect callback called while connected.')
+
+    def protocol_lost_connection(self, protocol):
+        """Protocol notification of lost connection."""
+        if self.connected:
+            _logger.info('Protocol lost connection.')
+            if protocol is not self.protocol:
+                _logger.error('Factory protocol callback called from unexpected protocol instance.')
+
+            self.connected = False
+            self.protocol = None
+            if self.host:
+                asyncio.async(self._reconnect(), loop=self.loop)
+        else:
+            _logger.error('Factory protocol disconnect callback called while not connected.')
+
+    @asyncio.coroutine
+    def _reconnect(self):
+        _logger.debug('Waiting %d ms before next connection attempt.' % self.delay_ms)
+        yield from asyncio.sleep(self.delay_ms / 1000)
+        self.delay_ms = min(2 * self.delay_ms, self.DELAY_MAX_MS)
+        yield from self._connect()

--- a/pymodbus/client/async_twisted.py
+++ b/pymodbus/client/async_twisted.py
@@ -1,0 +1,26 @@
+"""Asynchronous adapter implementation for Twisted."""
+from twisted.internet import defer, protocol
+from twisted.python.failure import Failure
+from pymodbus.client.async_common import AsyncModbusClientMixin
+
+
+class ModbusClientProtocol(protocol.Protocol, AsyncModbusClientMixin):
+    """Twisted specific implementation of asynchronous modbus client protocol."""
+
+    def connectionMade(self):
+        self._connectionMade()
+
+    def connectionLost(self, reason=protocol.connectionDone):
+        self._connectionLost(reason)
+
+    def dataReceived(self, data):
+        self._dataReceived(data)
+
+    def create_future(self):
+        return defer.Deferred()
+
+    def resolve_future(self, f, result):
+        f.callback(result)
+
+    def raise_future(self, f, exc):
+        f.errback(Failure(exc))

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(name  = 'pymodbus',
     include_package_data = True,
     zip_safe = True,
     install_requires = [
-        'twisted >= 13.1.0',
+        #'twisted >= 13.1.0',
         'pyserial >= 2.6'
     ],
     extras_require = {

--- a/test/asyncio_test_helper.py
+++ b/test/asyncio_test_helper.py
@@ -1,0 +1,52 @@
+import functools
+
+
+def _yielded_return(return_value, *args):
+    """Generator factory function with return value."""
+
+    def _():
+        """Actual generator producing value."""
+        yield
+        return return_value
+
+    # return new generator each time this function is called:
+    return _()
+
+
+def return_as_coroutine(return_value=None):
+    """Creates a function that behaves like an asyncio coroutine and returns the given value.
+
+    Typically used as a side effect of a mocked coroutine like this:
+
+        # in module mymod:
+        @asyncio.coroutine
+        def my_coro_under_test():
+            yield from asyncio.sleep(1)
+            yield from asyncio.sleep(2)
+            return 42
+
+        # in test module:
+        @mock.patch('mymod.asyncio.sleep')
+        def test_it(mock_sleep):
+            mock_sleep.side_effect = return_as_coroutine()
+            result = run_coroutine(my_coro_under_test)
+            assert mock_sleep.call_count == 2
+            assert mock_sleep.call_args_list == [mock.call(1), mock.call(2)]
+            assert result == 42
+    """
+    return functools.partial(_yielded_return, return_value)
+
+
+def run_coroutine(coro):
+    """Runs a coroutine as top-level task by iterating through all yielded steps."""
+
+    result = None
+    try:
+        # step through all parts of coro without scheduling anything else:
+        while True:
+            result = coro.send(result)
+    except StopIteration as ex:
+        # coro reached end pass on its return value:
+        return ex.value
+    except:
+        raise

--- a/test/test_client_async.py
+++ b/test/test_client_async.py
@@ -1,189 +1,195 @@
 #!/usr/bin/env python
-import unittest
-from mock import Mock
-from pymodbus.client.async import ModbusClientProtocol, ModbusUdpClientProtocol
-from pymodbus.client.async import ModbusClientFactory
-from pymodbus.exceptions import ConnectionException
-from pymodbus.exceptions import ParameterException
-from pymodbus.transaction import ModbusSocketFramer
-from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
 
-#---------------------------------------------------------------------------#
-# Fixture
-#---------------------------------------------------------------------------#
-class AsynchronousClientTest(unittest.TestCase):
-    '''
-    This is the unittest for the pymodbus.client.async module
-    '''
+# due to implicit twisted dependency in imports these tests to not run under
+# Python 3:
+from pymodbus.compat import IS_PYTHON2
+if IS_PYTHON2:
 
-    #-----------------------------------------------------------------------#
-    # Test Client Protocol
-    #-----------------------------------------------------------------------#
+    import unittest
+    from mock import Mock
+    from pymodbus.client.async import ModbusClientProtocol, ModbusUdpClientProtocol
+    from pymodbus.client.async import ModbusClientFactory
+    from pymodbus.exceptions import ConnectionException
+    from pymodbus.exceptions import ParameterException
+    from pymodbus.transaction import ModbusSocketFramer
+    from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
 
-    def testClientProtocolInit(self):
-        ''' Test the client protocol initialize '''
-        protocol = ModbusClientProtocol()
-        self.assertEqual(0, len(list(protocol.transaction)))
-        self.assertFalse(protocol._connected)
-        self.assertTrue(isinstance(protocol.framer, ModbusSocketFramer))
+    #---------------------------------------------------------------------------#
+    # Fixture
+    #---------------------------------------------------------------------------#
+    class AsynchronousClientTest(unittest.TestCase):
+        '''
+        This is the unittest for the pymodbus.client.async module
+        '''
 
-        framer = object()
-        protocol = ModbusClientProtocol(framer=framer)
-        self.assertEqual(0, len(list(protocol.transaction)))
-        self.assertFalse(protocol._connected)
-        self.assertTrue(framer is protocol.framer)
+        #-----------------------------------------------------------------------#
+        # Test Client Protocol
+        #-----------------------------------------------------------------------#
 
-    def testClientProtocolConnect(self):
-        ''' Test the client protocol connect '''
-        protocol = ModbusClientProtocol()
-        self.assertFalse(protocol._connected)
-        protocol.connectionMade()
-        self.assertTrue(protocol._connected)
+        def testClientProtocolInit(self):
+            ''' Test the client protocol initialize '''
+            protocol = ModbusClientProtocol()
+            self.assertEqual(0, len(list(protocol.transaction)))
+            self.assertFalse(protocol._connected)
+            self.assertTrue(isinstance(protocol.framer, ModbusSocketFramer))
 
-    def testClientProtocolDisconnect(self):
-        ''' Test the client protocol disconnect '''
-        protocol = ModbusClientProtocol()
-        protocol.connectionMade()
-        def handle_failure(failure):
-            self.assertTrue(isinstance(failure.value, ConnectionException))
-        d = protocol._buildResponse(0x00)
-        d.addErrback(handle_failure)
+            framer = object()
+            protocol = ModbusClientProtocol(framer=framer)
+            self.assertEqual(0, len(list(protocol.transaction)))
+            self.assertFalse(protocol._connected)
+            self.assertTrue(framer is protocol.framer)
 
-        self.assertTrue(protocol._connected)
-        protocol.connectionLost('because')
-        self.assertFalse(protocol._connected)
+        def testClientProtocolConnect(self):
+            ''' Test the client protocol connect '''
+            protocol = ModbusClientProtocol()
+            self.assertFalse(protocol._connected)
+            protocol.connectionMade()
+            self.assertTrue(protocol._connected)
 
-    def testClientProtocolDataReceived(self):
-        ''' Test the client protocol data received '''
-        protocol = ModbusClientProtocol()
-        protocol.connectionMade()
-        out = []
-        data = b'\x00\x00\x12\x34\x00\x06\xff\x01\x01\x02\x00\x04'
+        def testClientProtocolDisconnect(self):
+            ''' Test the client protocol disconnect '''
+            protocol = ModbusClientProtocol()
+            protocol.connectionMade()
+            def handle_failure(failure):
+                self.assertTrue(isinstance(failure.value, ConnectionException))
+            d = protocol._buildResponse(0x00)
+            d.addErrback(handle_failure)
 
-        # setup existing request
-        d = protocol._buildResponse(0x00)
-        d.addCallback(lambda v: out.append(v))
+            self.assertTrue(protocol._connected)
+            protocol.connectionLost('because')
+            self.assertFalse(protocol._connected)
 
-        protocol.dataReceived(data)
-        self.assertTrue(isinstance(out[0], ReadCoilsResponse))
+        def testClientProtocolDataReceived(self):
+            ''' Test the client protocol data received '''
+            protocol = ModbusClientProtocol()
+            protocol.connectionMade()
+            out = []
+            data = b'\x00\x00\x12\x34\x00\x06\xff\x01\x01\x02\x00\x04'
 
-    def testClientProtocolExecute(self):
-        ''' Test the client protocol execute method '''
-        protocol = ModbusClientProtocol()
-        protocol.connectionMade()
-        protocol.transport = Mock()
-        protocol.transport.write = Mock()
+            # setup existing request
+            d = protocol._buildResponse(0x00)
+            d.addCallback(lambda v: out.append(v))
 
-        request = ReadCoilsRequest(1, 1)
-        d = protocol.execute(request)
-        tid = request.transaction_id
-        self.assertEqual(d, protocol.transaction.getTransaction(tid))
+            protocol.dataReceived(data)
+            self.assertTrue(isinstance(out[0], ReadCoilsResponse))
 
-    def testClientProtocolHandleResponse(self):
-        ''' Test the client protocol handles responses '''
-        protocol = ModbusClientProtocol()
-        protocol.connectionMade()
-        out = []
-        reply = ReadCoilsRequest(1, 1)
-        reply.transaction_id = 0x00
+        def testClientProtocolExecute(self):
+            ''' Test the client protocol execute method '''
+            protocol = ModbusClientProtocol()
+            protocol.connectionMade()
+            protocol.transport = Mock()
+            protocol.transport.write = Mock()
 
-        # handle skipped cases
-        protocol._handleResponse(None)
-        protocol._handleResponse(reply)
+            request = ReadCoilsRequest(1, 1)
+            d = protocol.execute(request)
+            tid = request.transaction_id
+            self.assertEqual(d, protocol.transaction.getTransaction(tid))
 
-        # handle existing cases
-        d = protocol._buildResponse(0x00)
-        d.addCallback(lambda v: out.append(v))
-        protocol._handleResponse(reply)
-        self.assertEqual(out[0], reply)
+        def testClientProtocolHandleResponse(self):
+            ''' Test the client protocol handles responses '''
+            protocol = ModbusClientProtocol()
+            protocol.connectionMade()
+            out = []
+            reply = ReadCoilsRequest(1, 1)
+            reply.transaction_id = 0x00
 
-    def testClientProtocolBuildResponse(self):
-        ''' Test the udp client protocol builds responses '''
-        protocol = ModbusClientProtocol()
-        self.assertEqual(0, len(list(protocol.transaction)))
+            # handle skipped cases
+            protocol._handleResponse(None)
+            protocol._handleResponse(reply)
 
-        def handle_failure(failure):
-            self.assertTrue(isinstance(failure.value, ConnectionException))
-        d = protocol._buildResponse(0x00)
-        d.addErrback(handle_failure)
-        self.assertEqual(0, len(list(protocol.transaction)))
+            # handle existing cases
+            d = protocol._buildResponse(0x00)
+            d.addCallback(lambda v: out.append(v))
+            protocol._handleResponse(reply)
+            self.assertEqual(out[0], reply)
 
-        protocol._connected = True
-        d = protocol._buildResponse(0x00)
-        self.assertEqual(1, len(list(protocol.transaction)))
+        def testClientProtocolBuildResponse(self):
+            ''' Test the udp client protocol builds responses '''
+            protocol = ModbusClientProtocol()
+            self.assertEqual(0, len(list(protocol.transaction)))
 
-    #-----------------------------------------------------------------------#
-    # Test Udp Client Protocol
-    #-----------------------------------------------------------------------#
+            def handle_failure(failure):
+                self.assertTrue(isinstance(failure.value, ConnectionException))
+            d = protocol._buildResponse(0x00)
+            d.addErrback(handle_failure)
+            self.assertEqual(0, len(list(protocol.transaction)))
 
-    def testUdpClientProtocolInit(self):
-        ''' Test the udp client protocol initialize '''
-        protocol = ModbusUdpClientProtocol()
-        self.assertEqual(0, len(list(protocol.transaction)))
-        self.assertTrue(isinstance(protocol.framer, ModbusSocketFramer))
+            protocol._connected = True
+            d = protocol._buildResponse(0x00)
+            self.assertEqual(1, len(list(protocol.transaction)))
 
-        framer = object()
-        protocol = ModbusClientProtocol(framer=framer)
-        self.assertTrue(framer is protocol.framer)
+        #-----------------------------------------------------------------------#
+        # Test Udp Client Protocol
+        #-----------------------------------------------------------------------#
 
-    def testUdpClientProtocolDataReceived(self):
-        ''' Test the udp client protocol data received '''
-        protocol = ModbusUdpClientProtocol()
-        out = []
-        data = b'\x00\x00\x12\x34\x00\x06\xff\x01\x01\x02\x00\x04'
-        server = ('127.0.0.1', 12345)
+        def testUdpClientProtocolInit(self):
+            ''' Test the udp client protocol initialize '''
+            protocol = ModbusUdpClientProtocol()
+            self.assertEqual(0, len(list(protocol.transaction)))
+            self.assertTrue(isinstance(protocol.framer, ModbusSocketFramer))
 
-        # setup existing request
-        d = protocol._buildResponse(0x00)
-        d.addCallback(lambda v: out.append(v))
+            framer = object()
+            protocol = ModbusClientProtocol(framer=framer)
+            self.assertTrue(framer is protocol.framer)
 
-        protocol.datagramReceived(data, server)
-        self.assertTrue(isinstance(out[0], ReadCoilsResponse))
+        def testUdpClientProtocolDataReceived(self):
+            ''' Test the udp client protocol data received '''
+            protocol = ModbusUdpClientProtocol()
+            out = []
+            data = b'\x00\x00\x12\x34\x00\x06\xff\x01\x01\x02\x00\x04'
+            server = ('127.0.0.1', 12345)
 
-    def testUdpClientProtocolExecute(self):
-        ''' Test the udp client protocol execute method '''
-        protocol = ModbusUdpClientProtocol()
-        protocol.transport = Mock()
-        protocol.transport.write = Mock()
+            # setup existing request
+            d = protocol._buildResponse(0x00)
+            d.addCallback(lambda v: out.append(v))
 
-        request = ReadCoilsRequest(1, 1)
-        d = protocol.execute(request)
-        tid = request.transaction_id
-        self.assertEqual(d, protocol.transaction.getTransaction(tid))
+            protocol.datagramReceived(data, server)
+            self.assertTrue(isinstance(out[0], ReadCoilsResponse))
 
-    def testUdpClientProtocolHandleResponse(self):
-        ''' Test the udp client protocol handles responses '''
-        protocol = ModbusUdpClientProtocol()
-        out = []
-        reply = ReadCoilsRequest(1, 1)
-        reply.transaction_id = 0x00
+        def testUdpClientProtocolExecute(self):
+            ''' Test the udp client protocol execute method '''
+            protocol = ModbusUdpClientProtocol()
+            protocol.transport = Mock()
+            protocol.transport.write = Mock()
 
-        # handle skipped cases
-        protocol._handleResponse(None)
-        protocol._handleResponse(reply)
+            request = ReadCoilsRequest(1, 1)
+            d = protocol.execute(request)
+            tid = request.transaction_id
+            self.assertEqual(d, protocol.transaction.getTransaction(tid))
 
-        # handle existing cases
-        d = protocol._buildResponse(0x00)
-        d.addCallback(lambda v: out.append(v))
-        protocol._handleResponse(reply)
-        self.assertEqual(out[0], reply)
+        def testUdpClientProtocolHandleResponse(self):
+            ''' Test the udp client protocol handles responses '''
+            protocol = ModbusUdpClientProtocol()
+            out = []
+            reply = ReadCoilsRequest(1, 1)
+            reply.transaction_id = 0x00
 
-    def testUdpClientProtocolBuildResponse(self):
-        ''' Test the udp client protocol builds responses '''
-        protocol = ModbusUdpClientProtocol()
-        self.assertEqual(0, len(list(protocol.transaction)))
+            # handle skipped cases
+            protocol._handleResponse(None)
+            protocol._handleResponse(reply)
 
-        d = protocol._buildResponse(0x00)
-        self.assertEqual(1, len(list(protocol.transaction)))
+            # handle existing cases
+            d = protocol._buildResponse(0x00)
+            d.addCallback(lambda v: out.append(v))
+            protocol._handleResponse(reply)
+            self.assertEqual(out[0], reply)
 
-    #-----------------------------------------------------------------------#
-    # Test Client Factories
-    #-----------------------------------------------------------------------#
+        def testUdpClientProtocolBuildResponse(self):
+            ''' Test the udp client protocol builds responses '''
+            protocol = ModbusUdpClientProtocol()
+            self.assertEqual(0, len(list(protocol.transaction)))
 
-    def testModbusClientFactory(self):
-        ''' Test the base class for all the clients '''
-        factory = ModbusClientFactory()
-        self.assertTrue(factory is not None)
+            d = protocol._buildResponse(0x00)
+            self.assertEqual(1, len(list(protocol.transaction)))
+
+        #-----------------------------------------------------------------------#
+        # Test Client Factories
+        #-----------------------------------------------------------------------#
+
+        def testModbusClientFactory(self):
+            ''' Test the base class for all the clients '''
+            factory = ModbusClientFactory()
+            self.assertTrue(factory is not None)
 
 #---------------------------------------------------------------------------#
 # Main

--- a/test/test_client_async_asyncio.py
+++ b/test/test_client_async_asyncio.py
@@ -1,0 +1,146 @@
+from unittest import mock
+from pymodbus.client.async_asyncio import ReconnectingAsyncioModbusTcpClient, ModbusClientProtocol
+from test.asyncio_test_helper import return_as_coroutine, run_coroutine
+
+
+def test_protocol_connection_state_propagation_to_factory():
+    protocol = ModbusClientProtocol()
+    assert protocol.factory is None
+    assert protocol.transport is None
+    assert not protocol._connected
+
+    protocol.factory = mock.MagicMock()
+
+    protocol.connection_made(mock.sentinel.TRANSPORT)
+    assert protocol.transport is mock.sentinel.TRANSPORT
+    protocol.factory.protocol_made_connection.assert_called_once_with(protocol)
+    assert protocol.factory.protocol_lost_connection.call_count == 0
+
+    protocol.factory.reset_mock()
+
+    protocol.connection_lost(mock.sentinel.REASON)
+    assert protocol.transport is None
+    assert protocol.factory.protocol_made_connection.call_count == 0
+    protocol.factory.protocol_lost_connection.assert_called_once_with(protocol)
+
+
+def test_factory_initialization_state():
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+    assert not client.connected
+    assert client.delay_ms < client.DELAY_MAX_MS
+
+    assert client.loop is mock_loop
+    assert client.protocol_class is mock_protocol_class
+
+
+def test_factory_reset_wait_before_reconnect():
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+    initial_delay = client.delay_ms
+    assert initial_delay > 0
+    client.delay_ms *= 2
+
+    assert client.delay_ms > initial_delay
+    client.reset_delay()
+    assert client.delay_ms == initial_delay
+
+
+def test_factory_stop():
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    assert not client.connected
+    client.stop()
+    assert not client.connected
+
+    # fake connected client:
+    client.protocol = mock.MagicMock()
+    client.connected = True
+
+    client.stop()
+    client.protocol.transport.close.assert_called_once_with()
+
+
+def test_factory_protocol_made_connection():
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    assert not client.connected
+    assert client.protocol is None
+    client.protocol_made_connection(mock.sentinel.PROTOCOL)
+    assert client.connected
+    assert client.protocol is mock.sentinel.PROTOCOL
+
+    client.protocol_made_connection(mock.sentinel.PROTOCOL_UNEXPECTED)
+    assert client.connected
+    assert client.protocol is mock.sentinel.PROTOCOL
+
+
+@mock.patch('pymodbus.client.async_asyncio.asyncio.async')
+def test_factory_protocol_lost_connection(mock_async):
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    assert not client.connected
+    assert client.protocol is None
+    client.protocol_lost_connection(mock.sentinel.PROTOCOL_UNEXPECTED)
+    assert not client.connected
+
+    # fake client ist connected and *then* looses connection:
+    client.connected = True
+    client.host = mock.sentinel.HOST
+    client.port = mock.sentinel.PORT
+    client.protocol = mock.sentinel.PROTOCOL
+
+    with mock.patch('pymodbus.client.async_asyncio.ReconnectingAsyncioModbusTcpClient._reconnect') as mock_reconnect:
+        mock_reconnect.return_value = mock.sentinel.RECONNECT_GENERATOR
+        client.protocol_lost_connection(mock.sentinel.PROTOCOL)
+        mock_async.assert_called_once_with(mock.sentinel.RECONNECT_GENERATOR, loop=mock_loop)
+    assert not client.connected
+    assert client.protocol is None
+
+
+@mock.patch('pymodbus.client.async_asyncio.asyncio.async')
+def test_factory_start_success(mock_async):
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    run_coroutine(client.start(mock.sentinel.HOST, mock.sentinel.PORT))
+    mock_loop.create_connection.assert_called_once_with(mock.ANY, mock.sentinel.HOST, mock.sentinel.PORT)
+    assert mock_async.call_count == 0
+
+
+@mock.patch('pymodbus.client.async_asyncio.asyncio.async')
+def test_factory_start_failing_and_retried(mock_async):
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    mock_loop.create_connection = mock.MagicMock(side_effect=Exception('Did not work.'))
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    # check whether reconnect is called upon failed connection attempt:
+    with mock.patch('pymodbus.client.async_asyncio.ReconnectingAsyncioModbusTcpClient._reconnect') as mock_reconnect:
+        mock_reconnect.return_value = mock.sentinel.RECONNECT_GENERATOR
+        run_coroutine(client.start(mock.sentinel.HOST, mock.sentinel.PORT))
+        mock_reconnect.assert_called_once_with()
+        mock_async.assert_called_once_with(mock.sentinel.RECONNECT_GENERATOR, loop=mock_loop)
+
+
+@mock.patch('pymodbus.client.async_asyncio.asyncio.sleep')
+def test_factory_reconnect(mock_sleep):
+    mock_protocol_class = mock.MagicMock()
+    mock_loop = mock.MagicMock()
+    client = ReconnectingAsyncioModbusTcpClient(protocol_class=mock_protocol_class, loop=mock_loop)
+
+    client.delay_ms = 5000
+
+    mock_sleep.side_effect = return_as_coroutine()
+    run_coroutine(client._reconnect())
+    mock_sleep.assert_called_once_with(5)
+    assert mock_loop.create_connection.call_count == 1

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -2,7 +2,11 @@
 import unittest
 import socket
 import serial
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
+
 from pymodbus.client.sync import ModbusTcpClient, ModbusUdpClient
 from pymodbus.client.sync import ModbusSerialClient, BaseModbusClient
 from pymodbus.exceptions import ConnectionException, NotImplementedException

--- a/test/test_server_async.py
+++ b/test/test_server_async.py
@@ -1,87 +1,91 @@
 #!/usr/bin/env python
-import unittest
-from mock import patch, Mock
-from pymodbus.device import ModbusDeviceIdentification
-from pymodbus.server.async import ModbusTcpProtocol, ModbusUdpProtocol
-from pymodbus.server.async import ModbusServerFactory
-from pymodbus.server.async import StartTcpServer, StartUdpServer, StartSerialServer
-from pymodbus.exceptions import ConnectionException, NotImplementedException
-from pymodbus.exceptions import ParameterException
-from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
+# due to implicit twisted dependency in imports these tests to not run under
+# Python 3:
+from pymodbus.compat import IS_PYTHON2
+if IS_PYTHON2:
 
-#---------------------------------------------------------------------------#
-# Fixture
-#---------------------------------------------------------------------------#
-class AsynchronousServerTest(unittest.TestCase):
-    '''
-    This is the unittest for the pymodbus.server.async module
-    '''
+    from mock import patch, Mock
+    from pymodbus.device import ModbusDeviceIdentification
+    from pymodbus.server.async import ModbusTcpProtocol, ModbusUdpProtocol
+    from pymodbus.server.async import ModbusServerFactory
+    from pymodbus.server.async import StartTcpServer, StartUdpServer, StartSerialServer
+    from pymodbus.exceptions import ConnectionException, NotImplementedException
+    from pymodbus.exceptions import ParameterException
+    from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
 
-    #-----------------------------------------------------------------------#
-    # Setup/TearDown
-    #-----------------------------------------------------------------------#
-
-    def setUp(self):
+    #---------------------------------------------------------------------------#
+    # Fixture
+    #---------------------------------------------------------------------------#
+    class AsynchronousServerTest(unittest.TestCase):
         '''
-        Initializes the test environment
+        This is the unittest for the pymodbus.server.async module
         '''
-        values = dict((i, '') for i in range(10))
-        identity = ModbusDeviceIdentification(info=values)
 
-    #-----------------------------------------------------------------------#
-    # Test Modbus Server Factory
-    #-----------------------------------------------------------------------#
+        #-----------------------------------------------------------------------#
+        # Setup/TearDown
+        #-----------------------------------------------------------------------#
 
-    def testModbusServerFactory(self):
-        ''' Test the base class for all the clients '''
-        factory = ModbusServerFactory(store=None)
-        self.assertEqual(factory.control.Identity.VendorName, '')
+        def setUp(self):
+            '''
+            Initializes the test environment
+            '''
+            values = dict((i, '') for i in range(10))
+            identity = ModbusDeviceIdentification(info=values)
 
-        identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-        factory = ModbusServerFactory(store=None, identity=identity)
-        self.assertEqual(factory.control.Identity.VendorName, 'VendorName')
+        #-----------------------------------------------------------------------#
+        # Test Modbus Server Factory
+        #-----------------------------------------------------------------------#
 
-    #-----------------------------------------------------------------------#
-    # Test Modbus TCP Server
-    #-----------------------------------------------------------------------#
-    def testTCPServerDisconnect(self):
-        protocol = ModbusTcpProtocol()
-        protocol.connectionLost('because of an error')
+        def testModbusServerFactory(self):
+            ''' Test the base class for all the clients '''
+            factory = ModbusServerFactory(store=None)
+            self.assertEqual(factory.control.Identity.VendorName, '')
 
-    #-----------------------------------------------------------------------#
-    # Test Modbus UDP Server
-    #-----------------------------------------------------------------------#
-    def testUdpServerInitialize(self):
-        protocol = ModbusUdpProtocol(store=None)
-        self.assertEqual(protocol.control.Identity.VendorName, '')
+            identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
+            factory = ModbusServerFactory(store=None, identity=identity)
+            self.assertEqual(factory.control.Identity.VendorName, 'VendorName')
 
-        identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-        protocol = ModbusUdpProtocol(store=None, identity=identity)
-        self.assertEqual(protocol.control.Identity.VendorName, 'VendorName')
+        #-----------------------------------------------------------------------#
+        # Test Modbus TCP Server
+        #-----------------------------------------------------------------------#
+        def testTCPServerDisconnect(self):
+            protocol = ModbusTcpProtocol()
+            protocol.connectionLost('because of an error')
 
-    #-----------------------------------------------------------------------#
-    # Test Modbus Server Startups
-    #-----------------------------------------------------------------------#
+        #-----------------------------------------------------------------------#
+        # Test Modbus UDP Server
+        #-----------------------------------------------------------------------#
+        def testUdpServerInitialize(self):
+            protocol = ModbusUdpProtocol(store=None)
+            self.assertEqual(protocol.control.Identity.VendorName, '')
 
-    #def testTcpServerStartup(self):
-    #    ''' Test that the modbus tcp async server starts correctly '''
-    #    with patch('twisted.internet.reactor') as mock_reactor:
-    #        StartTcpServer(context=None, console=True)
-    #        self.assertEqual(mock_reactor.listenTCP.call_count, 2)
-    #        self.assertEqual(mock_reactor.run.call_count, 1)
+            identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
+            protocol = ModbusUdpProtocol(store=None, identity=identity)
+            self.assertEqual(protocol.control.Identity.VendorName, 'VendorName')
 
-    #def testUdpServerStartup(self):
-    #    ''' Test that the modbus udp async server starts correctly '''
-    #    with patch('twisted.internet.reactor') as mock_reactor:
-    #        StartUdpServer(context=None)
-    #        self.assertEqual(mock_reactor.listenUDP.call_count, 1)
-    #        self.assertEqual(mock_reactor.run.call_count, 1)
+        #-----------------------------------------------------------------------#
+        # Test Modbus Server Startups
+        #-----------------------------------------------------------------------#
 
-    #def testSerialServerStartup(self):
-    #    ''' Test that the modbus serial async server starts correctly '''
-    #    with patch('twisted.internet.reactor') as mock_reactor:
-    #        StartSerialServer(context=None, port='/dev/ptmx')
-    #        self.assertEqual(mock_reactor.run.call_count, 1)
+        #def testTcpServerStartup(self):
+        #    ''' Test that the modbus tcp async server starts correctly '''
+        #    with patch('twisted.internet.reactor') as mock_reactor:
+        #        StartTcpServer(context=None, console=True)
+        #        self.assertEqual(mock_reactor.listenTCP.call_count, 2)
+        #        self.assertEqual(mock_reactor.run.call_count, 1)
+
+        #def testUdpServerStartup(self):
+        #    ''' Test that the modbus udp async server starts correctly '''
+        #    with patch('twisted.internet.reactor') as mock_reactor:
+        #        StartUdpServer(context=None)
+        #        self.assertEqual(mock_reactor.listenUDP.call_count, 1)
+        #        self.assertEqual(mock_reactor.run.call_count, 1)
+
+        #def testSerialServerStartup(self):
+        #    ''' Test that the modbus serial async server starts correctly '''
+        #    with patch('twisted.internet.reactor') as mock_reactor:
+        #        StartSerialServer(context=None, port='/dev/ptmx')
+        #        self.assertEqual(mock_reactor.run.call_count, 1)
 
 #---------------------------------------------------------------------------#
 # Main

--- a/test/test_server_sync.py
+++ b/test/test_server_sync.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python
 import unittest
-from mock import patch, Mock
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    from mock import patch, Mock
 import serial
 import socket
 
@@ -232,12 +235,14 @@ class SynchronousServerTest(unittest.TestCase):
     def testTcpServerClose(self):
         ''' test that the synchronous TCP server closes correctly '''
         with patch.object(socket.socket, 'bind') as mock_socket:
-            identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-            server = ModbusTcpServer(context=None, identity=identity)
-            server.threads.append(Mock(**{'running': True}))
-            server.server_close()
-            self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-            self.assertFalse(server.threads[0].running)
+            with patch.object(socket.socket, 'getsockname') as mock_getsockname:
+                with patch.object(socketserver.TCPServer, 'server_activate') as mock_activator:
+                    identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
+                    server = ModbusTcpServer(context=None, identity=identity)
+                    server.threads.append(Mock(**{'running': True}))
+                    server.server_close()
+                    self.assertEqual(server.control.Identity.VendorName, 'VendorName')
+                    self.assertFalse(server.threads[0].running)
 
     def testTcpServerProcess(self):
         ''' test that the synchronous TCP server processes requests '''
@@ -252,12 +257,14 @@ class SynchronousServerTest(unittest.TestCase):
     def testUdpServerClose(self):
         ''' test that the synchronous UDP server closes correctly '''
         with patch.object(socket.socket, 'bind') as mock_socket:
-            identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-            server = ModbusUdpServer(context=None, identity=identity)
-            server.threads.append(Mock(**{'running': True}))
-            server.server_close()
-            self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-            self.assertFalse(server.threads[0].running)
+            with patch.object(socket.socket, 'getsockname') as mock_getsockname:
+                with patch.object(socketserver.TCPServer, 'server_activate') as mock_activator:
+                    identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
+                    server = ModbusUdpServer(context=None, identity=identity)
+                    server.threads.append(Mock(**{'running': True}))
+                    server.server_close()
+                    self.assertEqual(server.control.Identity.VendorName, 'VendorName')
+                    self.assertFalse(server.threads[0].running)
 
     def testUdpServerProcess(self):
         ''' test that the synchronous UDP server processes requests '''
@@ -311,13 +318,15 @@ class SynchronousServerTest(unittest.TestCase):
         ''' Test the tcp server starting factory '''
         with patch.object(ModbusTcpServer, 'serve_forever') as mock_server:
             with patch.object(socketserver.TCPServer, 'server_bind') as mock_binder:
-                StartTcpServer()
+                with patch.object(socketserver.TCPServer, 'server_activate') as mock_activator:
+                    StartTcpServer()
 
     def testStartUdpServer(self):
         ''' Test the udp server starting factory '''
         with patch.object(ModbusUdpServer, 'serve_forever') as mock_server:
             with patch.object(socketserver.UDPServer, 'server_bind') as mock_binder:
-                StartUdpServer()
+                with patch.object(socketserver.TCPServer, 'server_activate') as mock_activator:
+                    StartUdpServer()
 
     def testStartSerialServer(self):
         ''' Test the serial server starting factory '''


### PR DESCRIPTION
Hi Galen,

this is the pull request, including the client code for asyncio support in Python 3 including tests and some adaptations to the existing tests. Asynchronous tests with Twisted imports have been disabled completely. Some adaptations were also made to synchronous server tests to provide mocks for standard library internal socket calls.

Also I kept the Twisted code in there to allow later merging of Python 3 and Python 2.

This pull request references a clean feature branch to ease your review.

Best,
Mike
