### PR TITLE
Patch: Extended timeout handling in ModbusTransactionManager

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -303,6 +303,8 @@ class ModbusSerialClient(BaseModbusClient):
         self.parity   = kwargs.get('parity',   Defaults.Parity)
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout  = kwargs.get('timeout',  Defaults.Timeout)
+        
+        self.socket_poll_rate = 0.1  # seconds -- magic number for how often to check the bus for data
 
     @staticmethod
     def __implementation(method):
@@ -325,9 +327,10 @@ class ModbusSerialClient(BaseModbusClient):
         '''
         if self.socket: return True
         try:
-            self.socket = serial.Serial(port=self.port, timeout=self.timeout,
-                bytesize=self.bytesize, stopbits=self.stopbits,
-                baudrate=self.baudrate, parity=self.parity)
+            self.socket = serial.Serial(port=self.port, 
+                timeout=self.socket_poll_rate, bytesize=self.bytesize, 
+                stopbits=self.stopbits, baudrate=self.baudrate, 
+                parity=self.parity)
         except serial.SerialException, msg:
             _logger.error(msg)
             self.close()

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -304,7 +304,8 @@ class ModbusSerialClient(BaseModbusClient):
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout  = kwargs.get('timeout',  Defaults.Timeout)
         
-        self.socket_poll_rate = 0.1  # seconds -- magic number for how often to check the bus for data
+        # Set a relatively fast timeout on self.socket.
+        self.socket_poll_rate = min(0.1, self.timeout)  
 
     @staticmethod
     def __implementation(method):

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -64,7 +64,6 @@ class ModbusTransactionManager(object):
             start_time = time.time()
             try:
                 self.client.connect()
-                _logger.debug("Sending request")
                 self.client._send(self.client.framer.buildPacket(request))
                 # I need to fix this to read the header and the result size,
                 # as this may not read the full result set, but right now
@@ -72,14 +71,11 @@ class ModbusTransactionManager(object):
                 result = ''
                 while result == '' and time.time() < start_time + self.client.timeout:
                     # Keep retrying until timeout elapses
-                    _logger.debug("Waiting for data...")
                     result = self.client._recv(1024)
                 if not result and self.retry_on_empty:
                     _logger.debug("No data received within timeout. Querying again")
                     retries -= 1
                     continue
-                elif len(result) < 20:
-                    _logger.debug("Exiting while loop for this: " + repr(result))
                 if _logger.isEnabledFor(logging.DEBUG):
                     _logger.debug("recv: " + " ".join([hex(ord(x)) for x in result]))
                 self.client.framer.processIncomingPacket(result, self.addTransaction)


### PR DESCRIPTION
Hi bashwork,

Long time no chat, hope you're well. I'm finally getting around to the PR you and I discussed last June.

Problem statement is, we're using ModbusSerialClient to talk to a solar inverter that responds to write holding registers requests with about a 1s delay. Using current pymodbus code, I either need to use a timeout >>1 s, or the FIFOTransactionManager will catch the inverter's response _after_ returning from read_holding_registers. If I use a long timeout, the call to `self.client._recv(1024)` will take the entire timeout to return; if not, I end up with a log file like [this one](http://www.jackweinste.in/s/2017-01-30_pymodbus_response_delay.txt). Note that at 2017-01-30 14:50:28,723 I submit a WriteHoldingRegistersRequest and its response is returned for the next call to read_holding_registers.

The truly correct way to handle this, as you mention in your comment in `ModbusTransactionManager.execute()`, would be to calculate the number of bytes we expect the response to contain, and call `self.client._recv(num_bytes)` instead of `self.client._recv(1024)`. That way we could both use a long socket timeout and avoid blocking for the whole timeout when a valid response is received.

I've been waiting to PR until I found time to implement that response length prediction. But I've been busy and it'd be some actual work... and I just haven't gotten to it.

Until then, would you accept this patch? I've reduced the serial socket's timeout and added a loop to poll it multiple times, handling the slow response while not affecting normal behavior.