### PR TITLE
Add new skip_bytes method to BinaryPayloadDecoder to skip over bytes

### DIFF
--- a/examples/common/modbus-payload.py
+++ b/examples/common/modbus-payload.py
@@ -34,6 +34,7 @@ client.connect()
 # - a 8 byte string 'abcdefgh'
 # - a 32 bit float 22.34
 # - a 16 bit unsigned int 0x1234
+# - another 16 bit unsigned int 0x5678
 # - an 8 bit int 0x12
 # - an 8 bit bitstring [0,1,0,1,1,0,1,0]
 #---------------------------------------------------------------------------# 
@@ -41,6 +42,7 @@ builder = BinaryPayloadBuilder(endian=Endian.Big)
 builder.add_string('abcdefgh')
 builder.add_32bit_float(22.34)
 builder.add_16bit_uint(0x1234)
+builder.add_16bit_uint(0x5678)
 builder.add_8bit_int(0x12)
 builder.add_bits([0,1,0,1,1,0,1,0])
 payload = builder.build()
@@ -57,6 +59,7 @@ result  = client.write_registers(address, payload, skip_encode=True, unit=1)
 # - a 8 byte string 'abcdefgh'
 # - a 32 bit float 22.34
 # - a 16 bit unsigned int 0x1234
+# - another 16 bit unsigned int which we will ignore
 # - an 8 bit int 0x12
 # - an 8 bit bitstring [0,1,0,1,1,0,1,0]
 #---------------------------------------------------------------------------# 
@@ -68,6 +71,7 @@ decoded = {
     'string': decoder.decode_string(8),
     'float': decoder.decode_32bit_float(),
     '16uint': decoder.decode_16bit_uint(),
+    'ignored': decoder.skip_bytes(2),
     '8int': decoder.decode_8bit_int(),
     'bits': decoder.decode_bits(),
 }

--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -349,6 +349,14 @@ class BinaryPayloadDecoder(object):
         self._pointer += size
         return self._payload[self._pointer - size:self._pointer]
 
+    def skip_bytes(self, nbytes):
+        ''' Skip n bytes in the buffer
+
+        :param nbytes: The number of bytes to skip
+        '''
+        self._pointer += nbytes
+        return None
+
 #---------------------------------------------------------------------------#
 # Exported Identifiers
 #---------------------------------------------------------------------------#

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -31,13 +31,15 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
                        b'\x01\x02\x00\x03\x00\x00\x00\x04\x00\x00\x00\x00' \
                        b'\x00\x00\x00\xff\xfe\xff\xfd\xff\xff\xff\xfc\xff' \
                        b'\xff\xff\xff\xff\xff\xff\x00\x00\xa0\x3f\x00\x00' \
-                       b'\x00\x00\x00\x00\x19\x40\x74\x65\x73\x74\x11'
+                       b'\x00\x00\x00\x00\x19\x40\x01\x00\x74\x65\x73\x74' \
+                       b'\x11'
 
         self.big_endian_payload = \
                        b'\x01\x00\x02\x00\x00\x00\x03\x00\x00\x00\x00\x00' \
                        b'\x00\x00\x04\xff\xff\xfe\xff\xff\xff\xfd\xff\xff' \
                        b'\xff\xff\xff\xff\xff\xfc\x3f\xa0\x00\x00\x40\x19' \
-                       b'\x00\x00\x00\x00\x00\x00\x74\x65\x73\x74\x11'
+                       b'\x00\x00\x00\x00\x00\x00\x00\x01\x74\x65\x73\x74' \
+                       b'\x11'
 
         self.bitstring = [True, False, False, False, True, False, False, False]
 
@@ -62,6 +64,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         builder.add_64bit_int(-4)
         builder.add_32bit_float(1.25)
         builder.add_64bit_float(6.25)
+        builder.add_16bit_uint(1)      # placeholder
         builder.add_string(b'test')
         builder.add_bits(self.bitstring)
         self.assertEqual(self.little_endian_payload, builder.to_string())
@@ -79,6 +82,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         builder.add_64bit_int(-4)
         builder.add_32bit_float(1.25)
         builder.add_64bit_float(6.25)
+        builder.add_16bit_uint(1)      # placeholder
         builder.add_string('test')
         builder.add_bits(self.bitstring)
         self.assertEqual(self.big_endian_payload, builder.to_string())
@@ -125,6 +129,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         self.assertEqual(-4,     decoder.decode_64bit_int())
         self.assertEqual(1.25,   decoder.decode_32bit_float())
         self.assertEqual(6.25,   decoder.decode_64bit_float())
+        self.assertEqual(None,   decoder.skip_bytes(2))
         self.assertEqual('test', decoder.decode_string(4).decode())
         self.assertEqual(self.bitstring, decoder.decode_bits())
 
@@ -141,6 +146,7 @@ class ModbusPayloadUtilityTests(unittest.TestCase):
         self.assertEqual(-4,     decoder.decode_64bit_int())
         self.assertEqual(1.25,   decoder.decode_32bit_float())
         self.assertEqual(6.25,   decoder.decode_64bit_float())
+        self.assertEqual(None,   decoder.skip_bytes(2))
         self.assertEqual(b'test', decoder.decode_string(4))
         self.assertEqual(self.bitstring, decoder.decode_bits())
 


### PR DESCRIPTION
It is clearer in client code to use a method like this than reading a string of n bytes and discarding the return value.