### PR TITLE
Do not trigger InvalidMessageRecievedException for incomplete frame 

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -460,7 +460,7 @@ class ModbusSocketFramer(IModbusFramer):
 
     def _process(self, callback, error=False):
         """
-        Process incoming packets irrespective error condition 
+        Process incoming packets irrespective error condition
         """
         data = self.getRawFrame() if error else self.getFrame()
         result = self.decoder.decode(data)
@@ -486,7 +486,7 @@ class ModbusSocketFramer(IModbusFramer):
 
     def getRawFrame(self):
         """
-        Returns the complete buffer 
+        Returns the complete buffer
         """
         return self.__buffer
 
@@ -670,22 +670,29 @@ class ModbusRtuFramer(IModbusFramer):
         :param data: The new packet data
         :param callback: The function to send results to
         '''
+
         self.addToFrame(data)
-        while True:
-            if self.isFrameReady():
-                if self.checkFrame():
-                    self._process(callback)
-                else:
-                    # Could be an error response
-                    if len(self.__buffer):
-                        # Possible error ???
-                       self._process(callback, error=True)
-            else:
-                if len(self.__buffer):
-                    # Possible error ???
-                    if self.__header.get('len', 0) < 2:
-                        self._process(callback, error=True)
-                break
+        if self.isFrameReady():
+            if self.checkFrame():
+                self._process(callback)
+
+        # previous fix attempt:
+        # self.addToFrame(data)
+        # while True:
+        #     if self.isFrameReady():
+        #         if self.checkFrame():
+        #             self._process(callback)
+        #         else:
+        #             # Could be an error response
+        #             if len(self.__buffer):
+        #                 # Possible error ???
+        #                self._process(callback, error=True)
+        #     else:
+        #         if len(self.__buffer):
+        #             # Possible error ???
+        #             if self.__header.get('len', 0) < 2:
+        #                 self._process(callback, error=True)
+        #         break
 
     def buildPacket(self, message):
         ''' Creates a ready to send modbus packet


### PR DESCRIPTION
**The following changes retrieve a valid response object but need to be reviewed.**

It is not clear why a ``while`` loop was used. Nothing seems to change the buffer within this block.
Function ``dataReceived`` of ``twisted.internet.protocol.Protocol`` triggers ``processIncomingPacket`` everytime data was read and appends this to the
buffer.

Please review the following changes. Especially the ``self._process`` calls with the ``kwarg error=True``.

Further questions:
* Do we need to reset the buffer?
* What happens if the client reads only a chunk of the frame and the cable gets unplugged?
  The next time we request new registers we would append the data from the second call to the present buffer which leads to an invalid frame.

#212 