### PR TITLE
Add connected property to AsyncModbusClientMixin.

### DIFF
--- a/pymodbus/client/async_asyncio.py
+++ b/pymodbus/client/async_asyncio.py
@@ -33,10 +33,12 @@ class ModbusClientProtocol(asyncio.Protocol, AsyncModbusClientMixin):
         return asyncio.Future()
 
     def resolve_future(self, f, result):
-        f.set_result(result)
+        if not f.done():
+            f.set_result(result)
 
     def raise_future(self, f, exc):
-        f.set_exception(exc)
+        if not f.done():
+            f.set_exception(exc)
 
 
 class ReconnectingAsyncioModbusTcpClient(object):

--- a/pymodbus/client/async_common.py
+++ b/pymodbus/client/async_common.py
@@ -56,6 +56,12 @@ class AsyncModbusClientMixin(ModbusClientMixin):
         for tid in list(self.transaction):
             self.raise_future(self.transaction.getTransaction(tid), ConnectionException('Connection lost during request'))
 
+    @property
+    def connected(self):
+        """ Return connection status.
+        """
+        return self._connected
+
     def _dataReceived(self, data):
         ''' Get response, check for valid message, decode result
 


### PR DESCRIPTION
When using `pymodbus` with [pyserial-asyncio](https://github.com/pyserial/pyserial-asyncio) ther is problem when calling protocol right after creation pair of transport an protocol.
On [transport initialization](https://github.com/pyserial/pyserial-asyncio/blob/ab62188e6e3d866747da8af06684975ceb478108/serial_asyncio/__init__.py#L68) `protocol.connection_made` callback is being added via `loop.call_soon` so that [this example](https://github.com/riptideio/pymodbus/blob/11feecb464518658b9f75dc2684b25c7e4a6c87e/examples/contrib/asynchronous-asyncio-serial-client.py) works because [`client.read_coils`](https://github.com/riptideio/pymodbus/blob/11feecb464518658b9f75dc2684b25c7e4a6c87e/examples/contrib/asynchronous-asyncio-serial-client.py#L30) is called from coroutine (after several event loop iterations). 

When I use it like this: 
```
transport, protocol = await create_serial_connection(...)
coils = await protocol.read_coils(...)
```
I am getting error `'NoneType' object has no attribute 'write'` because transport is not assigned yet to protocol. 

`connected` property allows for such workaround: 
```
while not protocol.connected:
    await asyncio.sleep(0)  # let event loop run
```

Maybe transport should be responsible for awaiting `connection_made` inside initializer? 