### PR TITLE
#82: Error response API

### DIFF
--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -128,6 +128,9 @@ class ModbusResponse(ModbusPDU):
         ''' Proxy to the lower level initializer '''
         ModbusPDU.__init__(self, **kwargs)
 
+    def isError(self):
+        return False if self.function_code < 0x80 else True
+
 
 #---------------------------------------------------------------------------#
 # Exception PDU's


### PR DESCRIPTION
Added API in response to allow users to easily to check for errors in stead of having to manually compare response codes.

Eg:
        response = client.write_registers(...)
        assert(response.isError() == False)


