### PR TITLE
TimeoutError is not defined on Python 2.

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -14,6 +14,12 @@ from pymodbus.utilities  import checkCRC, computeCRC
 from pymodbus.utilities  import checkLRC, computeLRC
 from pymodbus.compat import iterkeys, imap, byte2int
 
+# Python 2 compatibility.
+try:
+    TimeoutError
+except NameError:
+    TimeoutError = socket.timeout
+
 #---------------------------------------------------------------------------#
 # Logging
 #---------------------------------------------------------------------------#
@@ -186,7 +192,7 @@ class ModbusTransactionManager(object):
                             # If no response being recived there
                             # is no point in conitnuing
                             break
-                    except (TimeoutError, SerialException):
+                    except (TimeoutError, socket.timeout, SerialException):
                         break
                 else:
                     break


### PR DESCRIPTION
Fallback to socket.error on Python 2 when we catch TimeoutError.

Also, socket.timeout can still be raised on Python 3 with different
semantics than TimeoutError, so we catch it as well.

Fix #263.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
