### PR TITLE
Reset delay on successful reconnect

### DIFF
--- a/pymodbus/client/async/asyncio/__init__.py
+++ b/pymodbus/client/async/asyncio/__init__.py
@@ -210,10 +210,8 @@ class ReconnectingAsyncioModbusTcpClient(object):
     """
     Client to connect to modbus device repeatedly over TCP/IP."
     """
-
-    #: Reconnect delay in milli seconds.
-    delay_ms = 0
-
+    #: Minimum delay in milli seconds before reconnect is attempted.
+    DELAY_MIN_MS = 100
     #: Maximum delay in milli seconds before reconnect is attempted.
     DELAY_MAX_MS = 1000 * 60 * 5
 
@@ -229,18 +227,17 @@ class ReconnectingAsyncioModbusTcpClient(object):
         self.protocol = None
         #: Event loop to use.
         self.loop = loop or asyncio.get_event_loop()
-
         self.host = None
         self.port = 0
-
         self.connected = False
-        self.reset_delay()
+        #: Reconnect delay in milli seconds.
+        self.delay_ms = self.DELAY_MIN_MS
 
     def reset_delay(self):
         """
         Resets wait before next reconnect to minimal period.
         """
-        self.delay_ms = 100
+        self.delay_ms = self.DELAY_MIN_MS
 
     @asyncio.coroutine
     def start(self, host, port=502):
@@ -286,10 +283,12 @@ class ReconnectingAsyncioModbusTcpClient(object):
             yield from self.loop.create_connection(self._create_protocol,
                                                    self.host,
                                                    self.port)
-            _logger.info('Connected to %s:%s.' % (self.host, self.port))
         except Exception as ex:
             _logger.warning('Failed to connect: %s' % ex)
             asyncio.async(self._reconnect(), loop=self.loop)
+        else:
+            _logger.info('Connected to %s:%s.' % (self.host, self.port))
+            self.reset_delay()
 
     def protocol_made_connection(self, protocol):
         """


### PR DESCRIPTION
The reconnect delay `delay_ms` in `ReconnectingAsyncioModbusTcpClient` should be reset after a connection has been established. Otherwise the reconnect delay will start at an unnecessary high value if the connection is lost again.