### PR TITLE
Fix AsyncioModbusSerialClient (serial options and create_serial_connection usage)

### DIFF
--- a/pymodbus/client/async/asyncio/__init__.py
+++ b/pymodbus/client/async/asyncio/__init__.py
@@ -660,7 +660,7 @@ class AsyncioModbusSerialClient(object):
     framer = None
 
     def __init__(self, port, protocol_class=None, framer=None,  loop=None,
-                 baudrate=9600, bytesize=8, parity='E', stopbits=1):
+                 baudrate=9600, bytesize=8, parity='N', stopbits=1):
         """
         Initializes Asyncio Modbus Serial Client
         :param port: Port to connect

--- a/pymodbus/client/async/asyncio/__init__.py
+++ b/pymodbus/client/async/asyncio/__init__.py
@@ -725,7 +725,7 @@ class AsyncioModbusSerialClient(object):
         Protocol notification of successful connection.
         """
         _logger.info('Protocol made connection.')
-        if not self._connected_event.is_set():
+        if not self._connected:
             self._connected_event.set()
             self.protocol = protocol
         else:
@@ -736,7 +736,7 @@ class AsyncioModbusSerialClient(object):
         """
         Protocol notification of lost connection.
         """
-        if self._connected_event.is_set():
+        if self._connected:
             _logger.info('Protocol lost connection.')
             if protocol is not self.protocol:
                 _logger.error('Factory protocol callback called'

--- a/pymodbus/client/async/factory/serial.py
+++ b/pymodbus/client/async/factory/serial.py
@@ -103,9 +103,7 @@ def async_io_factory(port=None, framer=None, **kwargs):
 
     client = AsyncioModbusSerialClient(port, proto_cls, framer, loop, **kwargs)
     coro = client.connect()
-    transport, protocol = loop.run_until_complete(asyncio.gather(coro))[0]
-    client.transport = transport
-    client.protocol = protocol
+    loop.run_until_complete(coro)
     return loop, client
 
 

--- a/pymodbus/client/async/factory/serial.py
+++ b/pymodbus/client/async/factory/serial.py
@@ -84,7 +84,7 @@ def async_io_factory(port=None, framer=None, **kwargs):
     Factory to create asyncio based async serial clients
     :param port:  Serial port
     :param framer: Modbus Framer
-    :param kwargs:
+    :param kwargs: Serial port options
     :return: asyncio event loop and serial client
     """
     import asyncio
@@ -101,8 +101,8 @@ def async_io_factory(port=None, framer=None, **kwargs):
         import sys
         sys.exit(1)
 
-    client = AsyncioModbusSerialClient(port, proto_cls, framer, loop)
-    coro = client._create_protocol()
+    client = AsyncioModbusSerialClient(port, proto_cls, framer, loop, **kwargs)
+    coro = client.connect()
     transport, protocol = loop.run_until_complete(asyncio.gather(coro))[0]
     client.transport = transport
     client.protocol = protocol


### PR DESCRIPTION
The API of serial_asyncio.create_serial_connection is different from the async socket API.
Also, the serial kwargs (baudrate etc.) were missing in AsyncioModbusSerialClient.__init__ Method.
