### PR TITLE
#232 fix triomotion communications

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -407,15 +407,6 @@ class ModbusSocketFramer(IModbusFramer):
         self._buffer = self._buffer[length:]
         self._header = {'tid':0, 'pid':0, 'len':0, 'uid':0}
 
-    def isFrameHeaderReady(self):
-        ''' Check if we should continue decode logic
-        This is meant to be used in a while loop in the decoding phase to let
-        the decoder factory know that there is still data in the buffer.
-
-        :returns: True if ready, False otherwise
-        '''
-        return len(self._buffer) > self._hsize
-
     def isFrameReady(self):
         ''' Check if we should continue decode logic
         This is meant to be used in a while loop in the decoding phase to let
@@ -471,7 +462,7 @@ class ModbusSocketFramer(IModbusFramer):
         '''
         _logger.debug(' '.join([hex(byte2int(x)) for x in data]))
         self.addToFrame(data)
-        while self.isFrameHeaderReady() and self.checkFrame():
+        while self.isFrameReady() and self.checkFrame():
             self._process(callback)
 
     def _process(self, callback, error=False):
@@ -497,7 +488,6 @@ class ModbusSocketFramer(IModbusFramer):
         end of the message (python just doesn't have the resolution to
         check for millisecond delays).
         '''
-        _logger.debug("resetFrame()")
         self._buffer = b''
         self._header = {'tid':0, 'pid':0, 'len':0, 'uid':0}
 

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -388,9 +388,9 @@ class ModbusSocketFramer(IModbusFramer):
             self._header['len'], self._header['uid'] = struct.unpack(
                     '>HHHB', self._buffer[0:self._hsize])
 
-            # someone sent a partial frame, frame not ready
-            #if self._header['len'] < 2:
-            #    self.advanceFrame()
+            # someone sent a short frame, move to next
+            if self._header['len'] < 2:
+                self.advanceFrame()
             # we have at least a complete message, continue
             if len(self._buffer) - self._hsize + 1 >= self._header['len']:
                 return True

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -13,3 +13,4 @@ redis>=2.10.5
 sqlalchemy>=1.1.15
 #wsgiref>=0.1.2
 cryptography>=1.8.1
+six==1.11.0

--- a/scripts/tcp_send_pdubytes.py
+++ b/scripts/tcp_send_pdubytes.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Send raw bytes over socket to reproduce error causing apu/pdus of
+# https://github.com/riptideio/pymodbus/issues/232
+
+import os
+import socket
+import sys
+import time
+
+def main():
+
+    # an array of arrays of bytearrays containing malformed, fragmented or incomplete modbus APUs
+    error_bytes=[]
+
+    # test apu #0, fragment of frame, incomplete header
+    error_bytes.insert(0,[b"\x00\x13\x00\x00\x00"])
+    
+    # test apu #1, complete frame, fragmented in data 
+    error_bytes.insert(1,[b"\x00\x0d\x00\x00\x00\x06\x01\x01",b"\x00\x00\x00\x01"])
+    
+    # test apu #2, complete frame, fragmented in header
+    error_bytes.insert(2,[b"\x00\x00\x00\x00\x00\x1d",
+        b"\x01\x10\x00\x00\x00\x0b\x16\x33\xfe\x00\x6f\x00\x1e\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"])
+    # test apu #3, two frames, second fragmented around data
+    error_bytes.insert(3,[b"\x00\x0d\x00\x00\x00\x06\x01\x01\x00\x00\x00\x01\x00\x0d\x00\x00\x00\x06\x01\x01",
+        b"\x00\x00\x00\x01"])
+    # test apu #4, two frames, read coils and write registers, with junk bytes following the first frame
+    error_bytes.insert(4,[b"\x00\x00\x00\x00\x00\x06\xfc\x01\x00\x02\x00\x03",b"\xe0\xdf\x09",b"\x00\x01\x00\x00\x00\x0b\xfc\x10\x00\x20\x00\x02\x04\x0a\x07\x10\xb4"]) 
+
+    # test apu #5, set trio float32 values, fragmented in data
+    error_bytes.insert(5,[b"\x05\x8e\x00\x00\x00\x1f\x01\x10\x00\x00\x00\x0c\x18\x00\x00\x00\x00\x00\x00\x3f\x80\x00\x00\x40\x00\x00\x00\x40\x40\x00\x00",b"\x40\x80\x00\x00\x40\xa0"])
+
+    # service under test
+    server_addr=('192.168.0.100',8020)
+
+    # run all tests
+    #for err_index in range(len(error_bytes)):
+    # or select a specific test
+    for err_index in [5]:
+
+        print("test packet #{} :\n\n{}".format(err_index,error_bytes[err_index]))
+        bytes_to_send=error_bytes[err_index]
+
+
+        mdbclient_sock=socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        mdbclient_sock.settimeout(0.1)
+        mdbclient_sock.connect(server_addr)
+
+        svr_resp_bytes=bytes()
+        for bytes_chunk in bytes_to_send:
+            print("Sending '{}'...".format(bytes_chunk))
+            try:
+                mdbclient_sock.sendall(bytes_chunk)
+                svr_resp_bytes=mdbclient_sock.recv(256)
+            except OSError as e:
+                print("Os error: {}".format(str(e)))
+                pass
+            except socket.timeout:
+                print("Socket timed out...")
+                pass
+
+            if len(svr_resp_bytes)>0:
+                print("Response '{}'".format(svr_resp_bytes))
+            else:
+                print("No response")
+
+            # can't control when tcp will send a segment, but pausing momentarily makes it
+            # more likely that the stack will send each 'bytes_chunk' independently,
+            # reproducing the error(s)
+            time.sleep(0.1)
+
+        mdbclient_sock.close()
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import six
 import unittest
 from binascii import a2b_hex
 from pymodbus.pdu import *
@@ -245,7 +246,7 @@ class ModbusTransactionTest(unittest.TestCase):
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
 
-        self.assertCountEqual(actual.results,expected_pdus)
+        six.assertCountEqual(self,actual.results,expected_pdus)
 
     def testTCPProcessPackets02(self):
         '''
@@ -273,7 +274,7 @@ class ModbusTransactionTest(unittest.TestCase):
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
 
-        self.assertCountEqual(actual.results,expected_pdus)
+        six.assertCountEqual(self,actual.results,expected_pdus)
 
     def testTCPProcessPackets03(self):
         '''
@@ -301,7 +302,7 @@ class ModbusTransactionTest(unittest.TestCase):
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
 
-        self.assertCountEqual(actual.results,expected_pdus)
+        six.assertCountEqual(self,actual.results,expected_pdus)
 
     def testTCPProcessPackets04(self):
         '''
@@ -330,7 +331,7 @@ class ModbusTransactionTest(unittest.TestCase):
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
 
-        self.assertCountEqual(actual.results,expected_pdus)
+        six.assertCountEqual(self,actual.results,expected_pdus)
 
     def testTCPProcessPackets05(self):
         '''
@@ -360,7 +361,7 @@ class ModbusTransactionTest(unittest.TestCase):
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
 
-        self.assertCountEqual(actual.results,expected_pdus)
+        six.assertCountEqual(self,actual.results,expected_pdus)
 
     #---------------------------------------------------------------------------#
     # RTU tests

--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -307,7 +307,6 @@ class ModbusTransactionTest(unittest.TestCase):
         '''
         Test two appended frames, read coils and write registers, fragmented in 2nd frame header
         '''
-        #mock_datas = [b"\x00\x00\x00\x00\x00\x06\xfc\x05\x00\x03\xff\x00",b"\x00\x01\x00\x00\x00\x06\xfc\x05\x00\x07\x00\x00"]
         mock_datas = [b"\x00\x00\x00\x00\x00\x06\xfc\x01\x00\x02\x00\x03\x00\x01\x00",
                 b"\x00\x00\x0b\xfc\x10\x00\x20\x00\x02\x04\x0a\x07\x10\xb4"]
         expected_pdus = [b"\x01\x00\x02\x00\x03",b"\x10\x00\x20\x00\x02\x04\x0a\x07\x10\xb4"]
@@ -338,7 +337,6 @@ class ModbusTransactionTest(unittest.TestCase):
         Test two frames, read coils and write registers, with junk bytes following the first frame
         Test will currently fail
         '''
-        #mock_datas = [b"\x00\x00\x00\x00\x00\x06\xfc\x05\x00\x03\xff\x00",b"\x00\x01\x00\x00\x00\x06\xfc\x05\x00\x07\x00\x00"]
         mock_datas = [b"\x00\x00\x00\x00\x00\x06\xfc\x01\x00\x02\x00\x03",b"\xe0\xdf\x09",
                 b"\x00\x01\x00\x00\x00\x0b\xfc\x10\x00\x20\x00\x02\x04\x0a\x07\x10\xb4"]
         expected_pdus = [b"\x01\x00\x02\x00\x03",b"\x10\x00\x20\x00\x02\x04\x0a\x07\x10\xb4"]
@@ -361,9 +359,6 @@ class ModbusTransactionTest(unittest.TestCase):
         self._tcp.resetFrame()
         for mock_chunk in mock_datas:
             self._tcp.processIncomingPacket(mock_chunk, actual.mock_callback)
-
-        print("expected: {}".format(expected_pdus))
-        print("actual  : {}".format(actual.results))
 
         self.assertCountEqual(actual.results,expected_pdus)
 


### PR DESCRIPTION
Instead of immediately discarding frame data, ModbusSocketFramer.processIncomingPacket() now saves partially received data for later processing.
ModbusSocketFramer.resetFrame() now sets self._header to the same dict as in __init__().