### PR TITLE
[FIX] undefined last_exception in transaction.execute

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -121,6 +121,7 @@ class ModbusTransactionManager(object):
                     expected_response_length = self._calculate_response_length(
                         response_pdu_size)
 
+        last_exception = None
         while retries > 0:
             try:
                 self.client.connect()


### PR DESCRIPTION
In commit 12c2ed4 the initialization of the variable `last_exception` was removed from transaction line 124. This causes an Exception if there is no response on the first Transaction (tested with the sync `ModbusSerialClient`). See:
https://github.com/riptideio/pymodbus/commit/12c2ed4df9b6335a2108a44961e3a7a0d6826353#diff-40a48d0b5cf576d37ccece3543183f65
I inserted the initialization `last_execption = None` before the retry while loop.