### PR TITLE
Update concurrent_client.py - Python3 compatbility

### DIFF
--- a/examples/contrib/concurrent_client.py
+++ b/examples/contrib/concurrent_client.py
@@ -214,7 +214,10 @@ class ConcurrentClient(ModbusClientMixin):
         :param request: The request to execute
         :returns: A future linked to the call's response
         """
-        fut, work_id = Future(), self.counter.next()
+        if IS_PYTHON3:
+            fut, work_id = Future(), next(self.counter)
+        else:
+            fut, work_id = Future(), self.counter.next()
         self.input_queue.put(WorkRequest(request, work_id))
         self.futures[work_id] = fut
         return fut


### PR DESCRIPTION
iter.next() was removed in python 3 so the code is broken on line 218.
This edit brings compatibility to python 3.
Successfully tested with Pythin 2.7.13 and 3.5.3

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
