### PR TITLE
Check received data length

### DIFF
--- a/pymodbus/exceptions.py
+++ b/pymodbus/exceptions.py
@@ -78,7 +78,7 @@ class ConnectionException(ModbusException):
         ModbusException.__init__(self, message)
 
 
-class InvalidMessageRecievedException(ModbusException):
+class InvalidMessageReceivedException(ModbusException):
     """
     Error resulting from invalid response received or decoded
     """

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -2,7 +2,7 @@ import struct
 import time
 
 from pymodbus.exceptions import ModbusIOException
-from pymodbus.exceptions import InvalidMessageRecievedException
+from pymodbus.exceptions import InvalidMessageReceivedException
 from pymodbus.utilities import checkCRC, computeCRC
 from pymodbus.utilities import hexlify_packets, ModbusTransactionState
 from pymodbus.compat import byte2int
@@ -313,7 +313,7 @@ class ModbusRtuFramer(ModbusFramer):
         if result is None:
             raise ModbusIOException("Unable to decode request")
         elif error and result.function_code < 0x80:
-            raise InvalidMessageRecievedException(result)
+            raise InvalidMessageReceivedException(result)
         else:
             self.populateResult(result)
             self.advanceFrame()

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -1,6 +1,6 @@
 import struct
 from pymodbus.exceptions import ModbusIOException
-from pymodbus.exceptions import InvalidMessageRecievedException
+from pymodbus.exceptions import InvalidMessageReceivedException
 from pymodbus.utilities import hexlify_packets
 from pymodbus.framer import ModbusFramer, SOCKET_FRAME_HEADER
 
@@ -174,7 +174,7 @@ class ModbusSocketFramer(ModbusFramer):
         if result is None:
             raise ModbusIOException("Unable to decode request")
         elif error and result.function_code < 0x80:
-            raise InvalidMessageRecievedException(result)
+            raise InvalidMessageReceivedException(result)
         else:
             self.populateResult(result)
             self.advanceFrame()


### PR DESCRIPTION
Hi @dhoomakethu ,
I made this PR mostly to solve the problem discussed in #188, this would fix that issue.
In the ```_recv``` function, the ```TransactionManager``` could receive an incomplete message like ```0xFF```, ```0x10``` or ```0x040101``` causing the raise of several exceptions because the actual length of the received message wasn't checked.

In addition i change the way that a message is received through a socket connection, so that ```recv(size)``` waits until full data is received, or timeout is expired. (That is consistent with ```read(size)``` function of serial client)

Let me know what you think.
Thanks 