### PR TITLE
Fixed byte count position for CommEventLogResponse

### DIFF
--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -278,7 +278,7 @@ class GetCommEventLogResponse(ModbusResponse):
     field defines the total length of the data in these four field
     '''
     function_code = 0x0c
-    _rtu_byte_count_pos = 3
+    _rtu_byte_count_pos = 2
 
     def __init__(self, **kwargs):
         ''' Initializes a new instance


### PR DESCRIPTION
_rtu_byte_count_pos for GetCommEventLogResponse is incorrect. This causes incorrect parsing of such responses from RTU slaves / servers.

For reference, a valid RTU response to this command, generated from hardware but using firmware I've written, looks like :
   0x5 0xc 0x9 0x0 0x0 0x0 0x0 0x0 0x3 0x80 0x42 0x80 0xb7 0xdd
(With a slave address of 0x5)

As an aside, though this PR does not address the problem, the exception produced is greatly misleading due to the 'Process incoming packets irrespective error condition' approach, which results in the ModbusClient attempting to parse the response using the slave address (unit) as the function code. This can be avoided by atleast stripping the prefix characters from the command (self._hsize) in the event of an error. 