### PR TITLE
Add support for MEI device identification encoding respecting PDU size and repeated Object IDs in the device identification

### DIFF
--- a/examples/contrib/deviceinfo_showcase_client.py
+++ b/examples/contrib/deviceinfo_showcase_client.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+"""
+Pymodbus Synchronous Client Example to showcase Device Information
+--------------------------------------------------------------------------
+
+This client demonstrates the use of Device Information to get information
+about servers connected to the client. This is part of the MODBUS specification,
+and uses the MEI 0x2B 0x0E request / response.
+"""
+# --------------------------------------------------------------------------- #
+# import the various server implementations
+# --------------------------------------------------------------------------- #
+from pymodbus.client.sync import ModbusTcpClient as ModbusClient
+# from pymodbus.client.sync import ModbusUdpClient as ModbusClient
+# from pymodbus.client.sync import ModbusSerialClient as ModbusClient
+
+# --------------------------------------------------------------------------- #
+# import the request
+# --------------------------------------------------------------------------- #
+from pymodbus.mei_message import ReadDeviceInformationRequest
+from pymodbus.device import ModbusDeviceIdentification
+
+# --------------------------------------------------------------------------- #
+# configure the client logging
+# --------------------------------------------------------------------------- #
+import logging
+FORMAT = ('%(asctime)-15s %(threadName)-15s '
+          '%(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
+logging.basicConfig(format=FORMAT)
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+UNIT = 0x1
+
+
+def run_sync_client():
+    # ------------------------------------------------------------------------#
+    # choose the client you want
+    # ------------------------------------------------------------------------#
+    # make sure to start an implementation to hit against. For this
+    # you can use an existing device, the reference implementation in the tools
+    # directory, or start a pymodbus server.
+    #
+    # If you use the UDP or TCP clients, you can override the framer being used
+    # to use a custom implementation (say RTU over TCP). By default they use
+    # the socket framer::
+    #
+    #    client = ModbusClient('localhost', port=5020, framer=ModbusRtuFramer)
+    #
+    # It should be noted that you can supply an ipv4 or an ipv6 host address
+    # for both the UDP and TCP clients.
+    #
+    # There are also other options that can be set on the client that controls
+    # how transactions are performed. The current ones are:
+    #
+    # * retries - Specify how many retries to allow per transaction (default=3)
+    # * retry_on_empty - Is an empty response a retry (default = False)
+    # * source_address - Specifies the TCP source address to bind to
+    #
+    # Here is an example of using these options::
+    #
+    #    client = ModbusClient('localhost', retries=3, retry_on_empty=True)
+    # ------------------------------------------------------------------------#
+    client = ModbusClient('localhost', port=5020)
+    # from pymodbus.transaction import ModbusRtuFramer
+    # client = ModbusClient('localhost', port=5020, framer=ModbusRtuFramer)
+    # client = ModbusClient(method='binary', port='/dev/ptyp0', timeout=1)
+    # client = ModbusClient(method='ascii', port='/dev/ptyp0', timeout=1)
+    # client = ModbusClient(method='rtu', port='/dev/ptyp0', timeout=1,
+    #                       baudrate=9600)
+    client.connect()
+
+    # ------------------------------------------------------------------------#
+    # specify slave to query
+    # ------------------------------------------------------------------------#
+    # The slave to query is specified in an optional parameter for each
+    # individual request. This can be done by specifying the `unit` parameter
+    # which defaults to `0x00`
+    # ----------------------------------------------------------------------- #
+    log.debug("Reading Device Information")
+    rq = ReadDeviceInformationRequest(read_code=0x03, object_id=0x00, unit=UNIT)
+    rr = client.execute(rq)
+    log.debug(rr)
+
+    print("Device Information : ")
+    for key in rr.information.keys():
+        print(key, rr.information[key])
+
+    # ----------------------------------------------------------------------- #
+    # You can also have the information parsed through the
+    # ModbusDeviceIdentificiation class, which gets you a more usable way
+    # to access the Basic and Regular device information objects which are
+    # specifically listed in the Modbus specification
+    # ----------------------------------------------------------------------- #
+    di = ModbusDeviceIdentification(info=rr.information)
+    print('Product Name : ', di.ProductName)
+
+    # ----------------------------------------------------------------------- #
+    # close the client
+    # ----------------------------------------------------------------------- #
+    client.close()
+
+
+if __name__ == "__main__":
+    run_sync_client()

--- a/examples/contrib/deviceinfo_showcase_client.py
+++ b/examples/contrib/deviceinfo_showcase_client.py
@@ -78,13 +78,20 @@ def run_sync_client():
     # which defaults to `0x00`
     # ----------------------------------------------------------------------- #
     log.debug("Reading Device Information")
-    rq = ReadDeviceInformationRequest(read_code=0x03, object_id=0x00, unit=UNIT)
-    rr = client.execute(rq)
-    log.debug(rr)
+    information = {}
+    rr = None
+
+    while not rr or rr.more_follows:
+        next_object_id = rr.next_object_id if rr else 0
+        rq = ReadDeviceInformationRequest(read_code=0x03, unit=UNIT,
+                                          object_id=next_object_id)
+        rr = client.execute(rq)
+        information.update(rr.information)
+        log.debug(rr)
 
     print("Device Information : ")
-    for key in rr.information.keys():
-        print(key, rr.information[key])
+    for key in information.keys():
+        print(key, information[key])
 
     # ----------------------------------------------------------------------- #
     # You can also have the information parsed through the
@@ -92,7 +99,7 @@ def run_sync_client():
     # to access the Basic and Regular device information objects which are
     # specifically listed in the Modbus specification
     # ----------------------------------------------------------------------- #
-    di = ModbusDeviceIdentification(info=rr.information)
+    di = ModbusDeviceIdentification(info=information)
     print('Product Name : ', di.ProductName)
 
     # ----------------------------------------------------------------------- #

--- a/examples/contrib/deviceinfo_showcase_server.py
+++ b/examples/contrib/deviceinfo_showcase_server.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python
+"""
+Pymodbus Synchronous Server Example to showcase Device Information
+--------------------------------------------------------------------------
+
+This server demonstrates the use of Device Information to provide information
+to clients about the device. This is part of the MODBUS specification, and
+uses the MEI 0x2B 0x0E request / response. This example creates an otherwise
+empty server.
+"""
+# --------------------------------------------------------------------------- # 
+# import the various server implementations
+# --------------------------------------------------------------------------- # 
+from pymodbus.server.sync import StartTcpServer
+from pymodbus.server.sync import StartUdpServer
+from pymodbus.server.sync import StartSerialServer
+
+from pymodbus.device import ModbusDeviceIdentification
+from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
+
+from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
+
+# --------------------------------------------------------------------------- #
+# import versions of libraries which we will use later on for the example
+# --------------------------------------------------------------------------- #
+from pymodbus import __version__ as pymodbus_version
+from serial import __version__ as pyserial_version
+
+# --------------------------------------------------------------------------- # 
+# configure the service logging
+# --------------------------------------------------------------------------- # 
+import logging
+FORMAT = ('%(asctime)-15s %(threadName)-15s'
+          ' %(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
+logging.basicConfig(format=FORMAT)
+log = logging.getLogger()
+log.setLevel(logging.DEBUG)
+
+
+def run_server():
+    # ----------------------------------------------------------------------- #
+    # initialize your data store
+    # ----------------------------------------------------------------------- #
+    store = ModbusSlaveContext()
+    context = ModbusServerContext(slaves=store, single=True)
+    
+    # ----------------------------------------------------------------------- # 
+    # initialize the server information
+    # ----------------------------------------------------------------------- # 
+    # If you don't set this or any fields, they are defaulted to empty strings.
+    # ----------------------------------------------------------------------- # 
+    identity = ModbusDeviceIdentification()
+    identity.VendorName = 'Pymodbus'
+    identity.ProductCode = 'PM'
+    identity.VendorUrl = 'http://github.com/riptideio/pymodbus/'
+    identity.ProductName = 'Pymodbus Server'
+    identity.ModelName = 'Pymodbus Server'
+    identity.MajorMinorRevision = '1.5'
+
+    # ----------------------------------------------------------------------- #
+    # Add an example with repeated object IDs. The MODBUS specification is
+    # entirely silent on whether or not this is allowed. In practice, this
+    # should be assumed to be contrary to the MODBUS specification and other
+    # clients (other than pymodbus) might behave differently when presented
+    # with an object ID occurring twice in the returned information.
+    #
+    # Use this at your discretion, and at the very least ensure that all
+    # objects which share a single object ID can fit together within a single
+    # ADU unit. In the case of Modbus RTU, this is about 240 bytes or so. In
+    # other words, when the spec says "An object is indivisible, therefore
+    # any object must have a size consistent with the size of transaction
+    # response", if you use repeated OIDs, apply that rule to the entire
+    # grouping of objects with the repeated OID.
+    # ----------------------------------------------------------------------- #
+    identity[0x81] = ['pymodbus {0}'.format(pymodbus_version),
+                      'pyserial {0}'.format(pyserial_version)]
+
+    # ----------------------------------------------------------------------- #
+    # run the server you want
+    # ----------------------------------------------------------------------- # 
+    # Tcp:
+    StartTcpServer(context, identity=identity, address=("localhost", 5020))
+
+    # TCP with different framer
+    # StartTcpServer(context, identity=identity,
+    #                framer=ModbusRtuFramer, address=("0.0.0.0", 5020))
+
+    # Udp:
+    # StartUdpServer(context, identity=identity, address=("0.0.0.0", 5020))
+    
+    # Ascii:
+    # StartSerialServer(context, identity=identity,
+    #                    port='/dev/ttyp0', timeout=1)
+    
+    # RTU:
+    # StartSerialServer(context, framer=ModbusRtuFramer, identity=identity,
+    #                   port='/dev/ttyp0', timeout=.005, baudrate=9600)
+
+    # Binary
+    # StartSerialServer(context,
+    #                   identity=identity,
+    #                   framer=ModbusBinaryFramer,
+    #                   port='/dev/ttyp0',
+    #                   timeout=1)
+
+
+if __name__ == "__main__":
+    run_server()

--- a/examples/contrib/deviceinfo_showcase_server.py
+++ b/examples/contrib/deviceinfo_showcase_server.py
@@ -58,6 +58,18 @@ def run_server():
     identity.MajorMinorRevision = '1.5'
 
     # ----------------------------------------------------------------------- #
+    # Add an example which is long enough to force the ReadDeviceInformation
+    # request / response to require multiple responses to send back all of the
+    # information.
+    # ----------------------------------------------------------------------- #
+
+    identity[0x80] = "Lorem ipsum dolor sit amet, consectetur adipiscing " \
+                     "elit. Vivamus rhoncus massa turpis, sit amet " \
+                     "ultrices orci semper ut. Aliquam tristique sapien in " \
+                     "lacus pharetra, in convallis nunc consectetur. Nunc " \
+                     "velit elit, vehicula tempus tempus sed. "
+
+    # ----------------------------------------------------------------------- #
     # Add an example with repeated object IDs. The MODBUS specification is
     # entirely silent on whether or not this is allowed. In practice, this
     # should be assumed to be contrary to the MODBUS specification and other

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -155,7 +155,14 @@ class ReadDeviceInformationResponse(ModbusResponse):
         while count < len(data):
             object_id, object_length = struct.unpack('>BB', data[count:count+2])
             count += object_length + 2
-            self.information[object_id] = data[count-object_length:count]
+            if object_id not in self.information.keys():
+                self.information[object_id] = data[count-object_length:count]
+            else:
+                if isinstance(self.information[object_id], list):
+                    self.information[object_id].append(data[count-object_length:count])
+                else:
+                    self.information[object_id] = [self.information[object_id],
+                                                   data[count - object_length:count]]
 
     def __str__(self):
         ''' Builds a representation of the response

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -15,6 +15,21 @@ from pymodbus.compat import iteritems, byte2int, IS_PYTHON3
 _MCB = ModbusControlBlock()
 
 
+class _OutOfSpaceException(Exception):
+    # This exception exists here as a simple, local way to manage response
+    # length control for the only MODBUS command which requires it under
+    # standard, non-error conditions. It and the structures associated with
+    # it should ideally be refactored and applied to all responses, however,
+    # since a Client can make requests which result in disallowed conditions,
+    # such as, for instance, requesting a register read of more registers
+    # than will fit in a single PDU. As per the specification, the PDU is
+    # restricted to 253 bytes, irrespective of the transport used.
+    #
+    # See Page 5/50 of MODBUS Application Protocol Specification V1.1b3.
+    def __init__(self, oid):
+        self.oid = oid
+
+
 #---------------------------------------------------------------------------#
 # Read Device Information
 #---------------------------------------------------------------------------#
@@ -115,13 +130,15 @@ class ReadDeviceInformationResponse(ModbusResponse):
         self.read_code = read_code or DeviceInformation.Basic
         self.information = information or {}
         self.number_of_objects = 0
-        self.conformity = 0x83 # I support everything right now
-
-        # TODO calculate
-        self.next_object_id = 0x00 # self.information[-1](0)
+        self.conformity = 0x83  # I support everything right now
+        self.next_object_id = 0x00
         self.more_follows = MoreData.Nothing
+        self.space_left = None
 
     def _encode_object(self, object_id, data):
+        self.space_left -= (2 + len(data))
+        if self.space_left <= 0:
+            raise _OutOfSpaceException(object_id)
         encoded_obj = struct.pack('>BB', object_id, len(data))
         if IS_PYTHON3:
             if isinstance(data, bytes):
@@ -140,14 +157,18 @@ class ReadDeviceInformationResponse(ModbusResponse):
         '''
         packet = struct.pack('>BBB', self.sub_function_code,
                              self.read_code, self.conformity)
-
+        self.space_left = 253 - 6
         objects = b''
-        for (object_id, data) in iteritems(self.information):
-            if isinstance(data, list):
-                for item in data:
-                    objects += self._encode_object(object_id, item)
-            else:
-                objects += self._encode_object(object_id, data)
+        try:
+            for (object_id, data) in iteritems(self.information):
+                if isinstance(data, list):
+                    for item in data:
+                        objects += self._encode_object(object_id, item)
+                else:
+                    objects += self._encode_object(object_id, data)
+        except _OutOfSpaceException as e:
+            self.next_object_id = e.oid
+            self.more_follows = MoreData.KeepReading
 
         packet += struct.pack('>BBB', self.more_follows, self.next_object_id,
                               self.number_of_objects)

--- a/test/test_mei_messages.py
+++ b/test/test_mei_messages.py
@@ -102,11 +102,33 @@ class ModbusMeiMessageTest(unittest.TestCase):
         result = handle.encode()
         self.assertEqual(result, message)
 
+    def testReadDeviceInformationResponseEncodeLong(self):
+        ''' Test that the read fifo queue response can encode '''
+        longstring = "Lorem ipsum dolor sit amet, consectetur adipiscing " \
+                     "elit. Vivamus rhoncus massa turpis, sit amet ultrices" \
+                     " orci semper ut. Aliquam tristique sapien in lacus " \
+                     "pharetra, in convallis nunc consectetur. Nunc velit " \
+                     "elit, vehicula tempus tempus sed. "
+
+        message  = b'\x0e\x01\x83\xFF\x80\x03'
+        message += b'\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
+        dataset  = {
+            0x00: 'Company',
+            0x01: 'Product',
+            0x02: 'v2.1.12',
+            0x80: longstring
+        }
+        handle  = ReadDeviceInformationResponse(
+            read_code=DeviceInformation.Basic, information=dataset)
+        result  = handle.encode()
+        self.assertEqual(result, message)
+        self.assertEqual("ReadDeviceInformationResponse(1)", str(handle))
+
     def testReadDeviceInformationResponseDecode(self):
         ''' Test that the read device information response can decode '''
         message  = b'\x0e\x01\x01\x00\x00\x05'
         message += b'\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
-        message += b'\x81\x04Test\x81\x08Repeated'
+        message += b'\x81\x04Test\x81\x08Repeated\x81\x07Another'
         handle  = ReadDeviceInformationResponse(read_code=0x00, information=[])
         handle.decode(message)
         self.assertEqual(handle.read_code, DeviceInformation.Basic)
@@ -114,7 +136,7 @@ class ModbusMeiMessageTest(unittest.TestCase):
         self.assertEqual(handle.information[0x00], b'Company')
         self.assertEqual(handle.information[0x01], b'Product')
         self.assertEqual(handle.information[0x02], b'v2.1.12')
-        self.assertEqual(handle.information[0x81], [b'Test', b'Repeated'])
+        self.assertEqual(handle.information[0x81], [b'Test', b'Repeated', b'Another'])
 
     def testRtuFrameSize(self):
         ''' Test that the read device information response can decode '''

--- a/test/test_mei_messages.py
+++ b/test/test_mei_messages.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 '''
 MEI Message Test Fixture
 --------------------------------
@@ -46,13 +45,21 @@ class ModbusMeiMessageTest(unittest.TestCase):
         control.Identity.VendorName  = "Company"
         control.Identity.ProductCode = "Product"
         control.Identity.MajorMinorRevision = "v2.1.12"
+        control.Identity.update({0x81: ['Test', 'Repeated']})
 
         handle  = ReadDeviceInformationRequest()
         result  = handle.execute(context)
         self.assertTrue(isinstance(result, ReadDeviceInformationResponse))
-        self.assertTrue(result.information[0x00], "Company")
-        self.assertTrue(result.information[0x01], "Product")
-        self.assertTrue(result.information[0x02], "v2.1.12")
+        self.assertEqual(result.information[0x00], "Company")
+        self.assertEqual(result.information[0x01], "Product")
+        self.assertEqual(result.information[0x02], "v2.1.12")
+        with self.assertRaises(KeyError):
+            _ = result.information[0x81]
+
+        handle = ReadDeviceInformationRequest(read_code=DeviceInformation.Extended,
+                                              object_id=0x80)
+        result = handle.execute(context)
+        self.assertEqual(result.information[0x81], ['Test', 'Repeated'])
 
     def testReadDeviceInformationRequestError(self):
         ''' Test basic bit message encoding/decoding '''
@@ -81,10 +88,25 @@ class ModbusMeiMessageTest(unittest.TestCase):
         self.assertEqual(result, message)
         self.assertEqual("ReadDeviceInformationResponse(1)", str(handle))
 
+        dataset = {
+            0x00: 'Company',
+            0x01: 'Product',
+            0x02: 'v2.1.12',
+            0x81: ['Test', 'Repeated']
+        }
+        message = b'\x0e\x03\x83\x00\x00\x05'
+        message += b'\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
+        message += b'\x81\x04Test\x81\x08Repeated'
+        handle = ReadDeviceInformationResponse(
+            read_code=DeviceInformation.Extended, information=dataset)
+        result = handle.encode()
+        self.assertEqual(result, message)
+
     def testReadDeviceInformationResponseDecode(self):
         ''' Test that the read device information response can decode '''
-        message  = b'\x0e\x01\x01\x00\x00\x03'
+        message  = b'\x0e\x01\x01\x00\x00\x05'
         message += b'\x00\x07Company\x01\x07Product\x02\x07v2.1.12'
+        message += b'\x81\x04Test\x81\x08Repeated'
         handle  = ReadDeviceInformationResponse(read_code=0x00, information=[])
         handle.decode(message)
         self.assertEqual(handle.read_code, DeviceInformation.Basic)
@@ -92,6 +114,7 @@ class ModbusMeiMessageTest(unittest.TestCase):
         self.assertEqual(handle.information[0x00], b'Company')
         self.assertEqual(handle.information[0x01], b'Product')
         self.assertEqual(handle.information[0x02], b'v2.1.12')
+        self.assertEqual(handle.information[0x81], [b'Test', b'Repeated'])
 
     def testRtuFrameSize(self):
         ''' Test that the read device information response can decode '''


### PR DESCRIPTION
This PR allows parsing of some kinds of non-standard MEI device information responses. In particular, if a device (modbus server) reply to an MEI device information request (0x2B 0x0E) includes multiple objects with the same ID. I am uncertain about whether any current devices do this, though given the fact that I have had good reason to add such behavior in my devices and the likes of #47, I would not be surprised if there are indeed a few which do so. 

This change included in this PR will cause no change in the behavior of any existing code with standard devices, and continues to return a dict with the object IDs as keys. However, in case an object ID is encountered twice, the value in the dictionary against that object ID (and only that object ID) is turned into a list. The objects in the list appear in the order in which they are encountered in the response. The performance cost to this approach should be minimal to the point of being negligible.

As an example of where I use such a mechanism, I dedicate one object ID to storing version numbers of included libraries in a semi-descriptive string. As multiple libraries are linked into the firmware, each adds a device information object with it's version string. Another example where I intend to use such behavior is to store per-channel calibration information in a client-readable format, in instances where the number of channels is not known before hand. 

I do currently have a functioning workaround, which subclasses ReadDeviceInformationResponse and makes the necessary changes. However, changing the Response parser and maintaining it separately does take a little more effort than I am quite comfortable with, given that ModbusSerialClient needs to subclassed as well and ClientDecoder needs to be replicated entirely.