### PR TITLE
Fix device information selectors

### DIFF
--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -220,7 +220,7 @@ class ModbusDeviceIdentification(object):
         '''
         if isinstance(info, dict):
             for key in info:
-                if (0x06 >= key >= 0x00) or (0x80 > key > 0x08):
+                if (0x06 >= key >= 0x00) or (0xFF >= key >= 0x80):
                     self.__data[key] = info[key]
 
     def __iter__(self):
@@ -287,10 +287,11 @@ class DeviceInformationFactory(Singleton):
     '''
 
     __lookup = {
-        DeviceInformation.Basic:    lambda c,r,i: c.__gets(r, list(range(0x00, 0x03))),
-        DeviceInformation.Regular:  lambda c,r,i: c.__gets(r, list(range(0x00, 0x08))),
-        DeviceInformation.Extended: lambda c,r,i: c.__gets(r, list(range(0x80, i))),
-        DeviceInformation.Specific: lambda c,r,i: c.__get(r, i),
+        DeviceInformation.Basic: lambda c, r, i: c.__gets(r, list(range(i, 0x03))),
+        DeviceInformation.Regular: lambda c, r, i: c.__gets(r, list(range(i, 0x07))),
+        DeviceInformation.Extended: lambda c, r, i:
+            c.__gets(r, [x for x in range(i, 0x100) if x not in range(0x07, 0x80)]),
+        DeviceInformation.Specific: lambda c, r, i: c.__get(r, i),
     }
 
     @classmethod
@@ -323,7 +324,7 @@ class DeviceInformationFactory(Singleton):
         :param object_ids: The specific object ids to read
         :returns: The requested data (id, length, value)
         '''
-        return dict((oid, identity[oid]) for oid in object_ids)
+        return dict((oid, identity[oid]) for oid in object_ids if identity[oid])
 
 
 #---------------------------------------------------------------------------#

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -288,9 +288,12 @@ class DeviceInformationFactory(Singleton):
 
     __lookup = {
         DeviceInformation.Basic: lambda c, r, i: c.__gets(r, list(range(i, 0x03))),
-        DeviceInformation.Regular: lambda c, r, i: c.__gets(r, list(range(i, 0x07))),
-        DeviceInformation.Extended: lambda c, r, i:
-            c.__gets(r, [x for x in range(i, 0x100) if x not in range(0x07, 0x80)]),
+        DeviceInformation.Regular: lambda c, r, i: c.__gets(r, list(range(i, 0x07))
+            if c.__get(r, i)[i] else list(range(0, 0x07))),
+        DeviceInformation.Extended: lambda c, r, i: c.__gets(r,
+            [x for x in range(i, 0x100) if x not in range(0x07, 0x80)]
+            if c.__get(r, i)[i] else
+            [x for x in range(0, 0x100) if x not in range(0x07, 0x80)]),
         DeviceInformation.Specific: lambda c, r, i: c.__get(r, i),
     }
 

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -93,8 +93,10 @@ class SimpleDataStoreTest(unittest.TestCase):
         self.assertEqual(sorted(result.keys()), [0x06, 0x80, 0x82, 0xFF])
         result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x80)
         self.assertEqual(sorted(result.keys()), [0x80, 0x82, 0xFF])
-        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x81)
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x82)
         self.assertEqual(sorted(result.keys()), [0x82, 0xFF])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x81)
+        self.assertEqual(sorted(result.keys()), [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x80, 0x82, 0xFF])
 
     def testBasicCommands(self):
         ''' Test device identification reading '''

--- a/test/test_device.py
+++ b/test/test_device.py
@@ -27,7 +27,10 @@ class SimpleDataStoreTest(unittest.TestCase):
             0x06: 'unittest',               # UserApplicationName
             0x07: 'x',                      # reserved
             0x08: 'x',                      # reserved
-            0x10: 'private'                 # private data
+            0x10: 'reserved',               # reserved
+            0x80: 'custom1',                # device specific start
+            0x82: 'custom2',                # device specific
+            0xFF: 'customlast',             # device specific last
         }
         self.ident   = ModbusDeviceIdentification(self.info)
         self.control = ModbusControlBlock()
@@ -71,6 +74,28 @@ class SimpleDataStoreTest(unittest.TestCase):
         self.assertEqual(result[0x05], 'bashwork')
         self.assertEqual(result[0x06], 'unittest')
 
+    def testDeviceInformationFactoryLookup(self):
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Basic, 0x00)
+        self.assertEqual(sorted(result.keys()), [0x00, 0x01, 0x02])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Basic, 0x02)
+        self.assertEqual(sorted(result.keys()), [0x02])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Regular, 0x00)
+        self.assertEqual(sorted(result.keys()), [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Regular, 0x01)
+        self.assertEqual(sorted(result.keys()), [0x01, 0x02, 0x03, 0x04, 0x05, 0x06])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Regular, 0x05)
+        self.assertEqual(sorted(result.keys()), [0x05, 0x06])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x00)
+        self.assertEqual(sorted(result.keys()), [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x80, 0x82, 0xFF])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x02)
+        self.assertEqual(sorted(result.keys()), [0x02, 0x03, 0x04, 0x05, 0x06, 0x80, 0x82, 0xFF])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x06)
+        self.assertEqual(sorted(result.keys()), [0x06, 0x80, 0x82, 0xFF])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x80)
+        self.assertEqual(sorted(result.keys()), [0x80, 0x82, 0xFF])
+        result = DeviceInformationFactory.get(self.control, DeviceInformation.Extended, 0x81)
+        self.assertEqual(sorted(result.keys()), [0x82, 0xFF])
+
     def testBasicCommands(self):
         ''' Test device identification reading '''
         self.assertEqual(str(self.ident),   "DeviceIdentity")
@@ -87,13 +112,13 @@ class SimpleDataStoreTest(unittest.TestCase):
         self.assertEqual(self.ident[0x06], 'unittest')
         self.assertNotEqual(self.ident[0x07], 'x')
         self.assertNotEqual(self.ident[0x08], 'x')
-        self.assertEqual(self.ident[0x10], 'private')
+        self.assertNotEqual(self.ident[0x10], 'reserved')
         self.assertEqual(self.ident[0x54], '')
 
     def testModbusDeviceIdentificationSummary(self):
         ''' Test device identification summary creation '''
         summary  = sorted(self.ident.summary().values())
-        expected = sorted(list(self.info.values())[:-3]) # remove private
+        expected = sorted(list(self.info.values())[:0x07]) # remove private
         self.assertEqual(summary, expected)
 
     def testModbusDeviceIdentificationSet(self):


### PR DESCRIPTION
This PR corrects the Modbus Device information object_ids and category boundaries to match with the MODBUS Application Protocol Specification (V1.1b3). This change will cause changes in behavior of existing code, but make it compatible with the specification. A middle ground may be considered which eliminates the intermediate 'reserved' section, making it possible for anyone using the current pymodbus private range of 0x08-0x80 to continue to do so. 

In any case, the extant implementation breaks compatibility with fully compliant Modbus clients, including pymodbus itself. These problems revealed themselves during the development of tests for PR #293, and will have to be fixed before #293 will have passing tests.

The following are the major elements of the specs the current code is in violation of : 

- The read device identification function provides a start object_id, which the spec recommends the client start reading at zero - though it need not be zero. In fact, all subsequent calls made necessary by long information strings and limitations of the ADU size will require non-zero values for the start object_id. It should then return all object IDs after it, stopping at the category boundary defined by the read type. 
- The range 0x07 - 0x7F is reserved, not private, and should ideally not be used at all.
- The range 0x80 - 0xFF is private, not out of bounds, and the content is device / server dependent. In this implementation we do make the additional assumption that any object_id with an empty string is a non-existing / invalid object_id.
