### PR TITLE
custom_message.py: typo: Synchrnonous -> Synchronous

### DIFF
--- a/examples/common/custom_message.py
+++ b/examples/common/custom_message.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 """
-Pymodbus Synchrnonous Client Examples
+Pymodbus Synchronous Client Examples
 --------------------------------------------------------------------------
 
 The following is an example of how to use the synchronous modbus client


### PR DESCRIPTION
I also did `grep -Ri synchrnonous` to find other occurrences, but there only seems to have been this one.