### PR TITLE
Adding six to install requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ setup(
     include_package_data=True,
     zip_safe=True,
     install_requires=[
-        'pyserial >= 2.6'
+        'pyserial >= 2.6',
+        'six'
     ],
     extras_require={
         'quality': [


### PR DESCRIPTION
Hello

I added six to the installation requirements in the setup.py so that when installing with pip six is automatically installed.

Bests