### PR TITLE
#322 reuse address

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -46,7 +46,6 @@ Version 1.5.0
 * Modbus read retries works only when empty/no message is received
 * Change test runner from nosetest to pytest
 * Fix Misc examples
->>>>>>> master
 
 Version 1.4.0
 ------------------------------------------------------------

--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -273,7 +273,8 @@ class ModbusTcpServer(socketserver.ThreadingTCPServer):
     """
 
     def __init__(self, context, framer=None, identity=None,
-                 address=None, handler=None, **kwargs):
+                 address=None, handler=None, allow_reuse_address=False,
+                 **kwargs):
         """ Overloaded initializer for the socket server
 
         If the identify structure is not passed in, the ModbusControlBlock
@@ -285,10 +286,13 @@ class ModbusTcpServer(socketserver.ThreadingTCPServer):
         :param address: An optional (interface, port) to bind to.
         :param handler: A handler for each client session; default is
                         ModbusConnectedRequestHandler
+        :param allow_reuse_address: Whether the server will allow the
+                        reuse of an address.
         :param ignore_missing_slaves: True to not send errors on a request
                                         to a missing slave
         """
         self.threads = []
+        self.allow_reuse_address = allow_reuse_address
         self.decoder = ServerDecoder()
         self.framer = framer or ModbusSocketFramer
         self.context = context or ModbusServerContext()


### PR DESCRIPTION
Allows reusing the address when running pymodbus synchronous server. A new keyword arg is introduced `allow_reuse_address` (set to false by default to be backward compatible) to control this feature.

```
class ModbusTcpServer(socketserver.ThreadingTCPServer):
    """
    A modbus threaded tcp socket server

    We inherit and overload the socket server so that we
    can control the client threads as well as have a single
    server context instance.
    """

    def __init__(self, context, framer=None, identity=None,
                 address=None, handler=None, allow_reuse_address=False,
                 **kwargs):
        """ Overloaded initializer for the socket server

        If the identify structure is not passed in, the ModbusControlBlock
        uses its own empty structure.

        :param context: The ModbusServerContext datastore
        :param framer: The framer strategy to use
        :param identity: An optional identify structure
        :param address: An optional (interface, port) to bind to.
        :param handler: A handler for each client session; default is
                        ModbusConnectedRequestHandler
        :param allow_reuse_address: Whether the server will allow the
                        reuse of an address.
        :param ignore_missing_slaves: True to not send errors on a request
                                        to a missing slave
        """

``` 

