### PR TITLE
Task Cancellation and CRC Errors

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -39,10 +39,7 @@ class BaseModbusClient(ModbusClientMixin):
         :param framer: The modbus framer implementation to use
         """
         self.framer = framer
-        if isinstance(self.framer, ModbusSocketFramer):
-            self.transaction = DictTransactionManager(self, **kwargs)
-        else:
-            self.transaction = FifoTransactionManager(self, **kwargs)
+        self.transaction = DictTransactionManager(self, **kwargs)
         self._debug = False
         self._debugfd = None
 

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -186,6 +186,7 @@ class ModbusRtuFramer(ModbusFramer):
         :param result: The response packet
         """
         result.unit_id = self._header['uid']
+        result.transaction_id = self._header['uid']
 
     # ----------------------------------------------------------------------- #
     # Public Member Functions
@@ -221,6 +222,9 @@ class ModbusRtuFramer(ModbusFramer):
                     _logger.debug("Not a valid unit id - {}, "
                                   "ignoring!!".format(self._header['uid']))
                     self.resetFrame()
+            else:
+                _logger.debug("Frame check failed, ignoring!!")
+                self.resetFrame()
         else:
             _logger.debug("Frame - [{}] not ready".format(data))
 
@@ -235,6 +239,7 @@ class ModbusRtuFramer(ModbusFramer):
                              message.unit_id,
                              message.function_code) + data
         packet += struct.pack(">H", computeCRC(packet))
+        message.transaction_id = message.unit_id  # Ensure that transaction is actually the unit id for serial comms
         return packet
 
     def sendPacket(self, message):


### PR DESCRIPTION
Alternate solution for #356 and #360.

Changes the RTU to make the transaction ID as the unit ID instead of an ever incrementing number.

Previously this transaction ID was always 0 on the receiving end but was the unique transaction ID on sending.

As such the FIFO buffer made the most sense. By tying it to the unit ID, we can recover from failure modes such as: -
- Asyncio task cancellations (eg. timeouts) #360
- Skipped responses from slaves. (hangs on master #360)
- CRC Errors #356
- Busy response

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
