### PR TITLE
Retry loop fix #404

### DIFF
--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -20,6 +20,10 @@ class Defaults(Singleton):
        The default number of times a client should retry the given
        request before failing (3)
 
+    .. attribute:: Backoff
+
+       The default exponential backoff delay (0.3 seconds)
+
     .. attribute:: RetryOnEmpty
 
        A flag indicating if a transaction should be retried in the
@@ -91,6 +95,7 @@ class Defaults(Singleton):
     '''
     Port                = 502
     Retries             = 3
+    Backoff             = 0.3
     RetryOnEmpty        = False
     Timeout             = 3
     Reconnects          = 0

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -5,6 +5,7 @@ Collection of transaction based abstractions
 
 import struct
 import socket
+import time
 from threading import RLock
 from functools import partial
 
@@ -63,6 +64,7 @@ class ModbusTransactionManager(object):
         self.client = client
         self.retry_on_empty = kwargs.get('retry_on_empty', Defaults.RetryOnEmpty)
         self.retries = kwargs.get('retries', Defaults.Retries) or 1
+        self.backoff = kwargs.get('backoff', Defaults.Backoff) or 0.3
         self._transaction_lock = RLock()
         self._no_response_devices = []
         if client:
@@ -135,32 +137,38 @@ class ModbusTransactionManager(object):
                     full = True
                     if not expected_response_length:
                         expected_response_length = Defaults.ReadSize
-                response, last_exception = self._transact(request,
-                                                          expected_response_length,
-                                                          full=full
-                                                          )
-                if not response and (
-                        request.unit_id not in self._no_response_devices):
-                    self._no_response_devices.append(request.unit_id)
-                elif request.unit_id in self._no_response_devices and response:
-                    self._no_response_devices.remove(request.unit_id)
-                if not response and self.retry_on_empty and retries:
-                    while retries > 0:
-                        if hasattr(self.client, "state"):
-                            _logger.debug("RESETTING Transaction state to "
-                                          "'IDLE' for retry")
-                            self.client.state = ModbusTransactionState.IDLE
-                        _logger.debug("Retry on empty - {}".format(retries))
-                        response, last_exception = self._transact(
-                            request,
-                            expected_response_length
-                        )
-                        if not response:
-                            retries -= 1
-                            continue
-                        # Remove entry
+
+                while retries > 0:
+                    response, last_exception = self._transact(
+                        request,
+                        expected_response_length,
+                        full=full
+                    )
+                    if not response and (
+                            request.unit_id not in self._no_response_devices):
+                        self._no_response_devices.append(request.unit_id)
+                    elif request.unit_id in self._no_response_devices and response:
                         self._no_response_devices.remove(request.unit_id)
+                    if not response and self.retry_on_empty:
+                        _logger.debug("Retry on empty - {}".format(retries))
+                    elif not response:
                         break
+                    if response:
+                        mbap = self.client.framer.decode_data(response)
+                        if (mbap['unit'] == request.unit_id and mbap['fcode'] == request.function_code):
+                            break
+                        if ('lenght' in mbap and expected_response_length and mbap['lenght'] == expected_response_length):
+                            break
+                        _logger.debug("Retry on invalid - {}".format(retries))
+                    if hasattr(self.client, "state"):
+                        _logger.debug("RESETTING Transaction state to 'IDLE' for retry")
+                        self.client.state = ModbusTransactionState.IDLE
+                    if self.backoff:
+                        delay = 2 ** (self.retries - retries) * self.backoff
+                        time.sleep(delay)
+                        _logger.debug("Sleeping {}".format(delay))
+                    retries -= 1
+
                 addTransaction = partial(self.addTransaction,
                                          tid=request.transaction_id)
                 self.client.framer.processIncomingPacket(response,


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Fully rewrited retry loop for no response and invalid response. These code almost fully solve our issues with a poor firmware energy measure field, surely Modbus specifications have many conditional and gaps about transaction retries so these might go over and above specs. NB: Tested with Modbus TCP only at now!