### PR TITLE
Remove unused pycrypto dep

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -6,7 +6,6 @@ mock >= 1.0.1
 pyserial-asyncio==0.4.0;python_version>="3.4"
 pep8>=1.7.0
 pyasn1>=0.2.3
-pycrypto>=2.6.1
 pyserial>=3.4
 pytest-cov>=2.5.1
 pytest>=3.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ six==1.11.0
 #Twisted==17.1.0
 #zope.interface==4.4.0
 #pyasn1==0.2.3
-#pycrypto==2.6.1
 #wsgiref==0.1.2
 #cryptography==1.8.1
 

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,6 @@ setup(
         'twisted': [
             'twisted >= 12.2.0',
             'pyasn1 >= 0.1.4',
-            'pycrypto >= 2.6'
         ],
         'tornado': [
             'tornado >= 4.5.3'


### PR DESCRIPTION
It has not been needed by Twisted for a long time, and has been unmaintained for a long time.

Fixes #402.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
