### PR TITLE
Padding for odd sized responses

### DIFF
--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -120,6 +120,7 @@ class DiagnosticStatusResponse(ModbusResponse):
         word_len = len(data)//2
         if len(data) % 2:
             word_len += 1
+            data = data + b'0'
         data = struct.unpack('>' + 'H'*word_len, data)
         self.sub_function_code, self.message = data[0], data[1:]
 


### PR DESCRIPTION
When running the GetClearModbusPlusRequest to retrieve statistics from a PLC the modbus message is 115 bytes long.
After stripping the Function Code the message is 113 bytes.
word_len was adjusted for the extra byte, but data wasn't.
The struct.unpack would fail since the buffer was 113 bytes, but the format was 114 bytes long.