### PR TITLE
Add TLS feature for ModbusTcpClient

### DIFF
--- a/examples/contrib/modbus_tls_client.py
+++ b/examples/contrib/modbus_tls_client.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Simple Modbus TCP over TLS client
+---------------------------------------------------------------------------
+
+This is a simple example of writing a modbus TCP over TLS client that uses
+Python builtin module ssl - TLS/SSL wrapper for socket objects for the TLS
+feature.
+"""
+# -------------------------------------------------------------------------- #
+# import neccessary libraries
+# -------------------------------------------------------------------------- #
+import ssl
+from pymodbus.client.sync import ModbusTlsClient
+
+# -------------------------------------------------------------------------- #
+# the TLS detail security can be set in SSLContext which is the context here
+# -------------------------------------------------------------------------- #
+context = ssl.create_default_context()
+context.options |= ssl.OP_NO_SSLv2
+context.options |= ssl.OP_NO_SSLv3
+context.options |= ssl.OP_NO_TLSv1
+context.options |= ssl.OP_NO_TLSv1_1
+
+# -------------------------------------------------------------------------- #
+# pass SSLContext which is the context here to ModbusTcpClient()
+# -------------------------------------------------------------------------- #
+client = ModbusTlsClient('test.host.com', 8020, sslctx=context)
+client.connect()
+
+result = client.read_coils(1, 8, unit=0x01)
+print(result.bits)
+
+client.close()

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -1,6 +1,7 @@
 import socket
 import select
 import time
+import ssl
 import sys
 from functools import partial
 from pymodbus.constants import Defaults
@@ -295,6 +296,116 @@ class ModbusTcpClient(BaseModbusClient):
             "<{} at {} socket={self.socket}, ipaddr={self.host}, "
             "port={self.port}, timeout={self.timeout}>"
         ).format(self.__class__.__name__, hex(id(self)), self=self)
+
+# --------------------------------------------------------------------------- #
+# Modbus TLS Client Transport Implementation
+# --------------------------------------------------------------------------- #
+
+
+class ModbusTlsClient(ModbusTcpClient):
+    """ Implementation of a modbus tls client
+    """
+
+    def __init__(self, host='localhost', port=Defaults.TLSPort, sslctx=None,
+        framer=ModbusSocketFramer, **kwargs):
+        """ Initialize a client instance
+
+        :param host: The host to connect to (default localhost)
+        :param port: The modbus port to connect to (default 802)
+        :param sslctx: The SSLContext to use for TLS (default None and auto create)
+        :param source_address: The source address tuple to bind to (default ('', 0))
+        :param timeout: The timeout to use for this socket (default Defaults.Timeout)
+        :param framer: The modbus framer to use (default ModbusSocketFramer)
+
+        .. note:: The host argument will accept ipv4 and ipv6 hosts
+        """
+        self.sslctx = sslctx
+        if self.sslctx is None:
+            self.sslctx = ssl.create_default_context()
+            # According to MODBUS/TCP Security Protocol Specification, it is
+            # TLSv2 at least
+            self.sslctx.options |= ssl.OP_NO_TLSv1_1
+            self.sslctx.options |= ssl.OP_NO_TLSv1
+            self.sslctx.options |= ssl.OP_NO_SSLv3
+            self.sslctx.options |= ssl.OP_NO_SSLv2
+        ModbusTcpClient.__init__(self, host, port, framer, **kwargs)
+
+    def connect(self):
+        """ Connect to the modbus tls server
+
+        :returns: True if connection succeeded, False otherwise
+        """
+        if self.socket: return True
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(self.source_address)
+            self.socket = self.sslctx.wrap_socket(sock, server_side=False,
+                                                  server_hostname=self.host)
+            self.socket.settimeout(self.timeout)
+            self.socket.connect((self.host, self.port))
+        except socket.error as msg:
+            _logger.error('Connection to (%s, %s) '
+                          'failed: %s' % (self.host, self.port, msg))
+            self.close()
+        return self.socket is not None
+
+    def _recv(self, size):
+        """ Reads data from the underlying descriptor
+
+        :param size: The number of bytes to read
+        :return: The bytes read
+        """
+        if not self.socket:
+            raise ConnectionException(self.__str__())
+
+        # socket.recv(size) waits until it gets some data from the host but
+        # not necessarily the entire response that can be fragmented in
+        # many packets.
+        # To avoid the splitted responses to be recognized as invalid
+        # messages and to be discarded, loops socket.recv until full data
+        # is received or timeout is expired.
+        # If timeout expires returns the read data, also if its length is
+        # less than the expected size.
+        timeout = self.timeout
+
+        # If size isn't specified read 1 byte at a time.
+        if size is None:
+            recv_size = 1
+        else:
+            recv_size = size
+
+        data = b''
+        time_ = time.time()
+        end = time_ + timeout
+        while recv_size > 0:
+            data += self.socket.recv(recv_size)
+            time_ = time.time()
+
+            # If size isn't specified continue to read until timeout expires.
+            if size:
+                recv_size = size - len(data)
+
+            # Timeout is reduced also if some data has been received in order
+            # to avoid infinite loops when there isn't an expected response
+            # size and the slave sends noisy data continuosly.
+            if time_ > end:
+                break
+
+        return data
+
+    def __str__(self):
+        """ Builds a string representation of the connection
+
+        :returns: The string representation
+        """
+        return "ModbusTlsClient(%s:%s)" % (self.host, self.port)
+
+    def __repr__(self):
+        return (
+            "<{} at {} socket={self.socket}, ipaddr={self.host}, "
+            "port={self.port}, sslctx={self.sslctx}, timeout={self.timeout}>"
+        ).format(self.__class__.__name__, hex(id(self)), self=self)
+
 
 # --------------------------------------------------------------------------- #
 # Modbus UDP Client Transport Implementation

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -15,6 +15,10 @@ class Defaults(Singleton):
 
        The default modbus tcp server port (502)
 
+    .. attribute:: TLSPort
+
+       The default modbus tcp over tls server port (802)
+
     .. attribute:: Retries
 
        The default number of times a client should retry the given
@@ -99,6 +103,7 @@ class Defaults(Singleton):
 
     '''
     Port                = 502
+    TLSPort             = 802
     Retries             = 3
     RetryOnEmpty        = False
     Timeout             = 3

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -8,8 +8,9 @@ else:  # Python 2
     from mock import patch, Mock, MagicMock
 import socket
 import serial
+import ssl
 
-from pymodbus.client.sync import ModbusTcpClient, ModbusUdpClient
+from pymodbus.client.sync import ModbusTcpClient, ModbusTlsClient, ModbusUdpClient
 from pymodbus.client.sync import ModbusSerialClient, BaseModbusClient
 from pymodbus.exceptions import ConnectionException, NotImplementedException
 from pymodbus.exceptions import ParameterException
@@ -157,7 +158,6 @@ class SynchronousClientTest(unittest.TestCase):
         )
         self.assertEqual(repr(client), rep)
 
-
     # -----------------------------------------------------------------------#
     # Test TCP Client
     # -----------------------------------------------------------------------#
@@ -249,6 +249,97 @@ class SynchronousClientTest(unittest.TestCase):
         client.framer = Mock()
         client.register(CustomeRequest)
         assert client.framer.decoder.register.called_once_with(CustomeRequest)
+
+    # -----------------------------------------------------------------------#
+    # Test TLS Client
+    # -----------------------------------------------------------------------#
+
+    def testSyncTlsClientInstantiation(self):
+        # default SSLContext
+        client = ModbusTlsClient()
+        self.assertNotEqual(client, None)
+        self.assertTrue(client.sslctx)
+
+        # user defined SSLContext
+        context = ssl.create_default_context()
+        client = ModbusTlsClient(sslctx=context)
+        self.assertNotEqual(client, None)
+        self.assertEqual(client.sslctx, context)
+
+    def testBasicSyncTlsClient(self):
+        ''' Test the basic methods for the tls sync client'''
+
+        # receive/send
+        client = ModbusTlsClient()
+        client.socket = mockSocket()
+        self.assertEqual(0, client._send(None))
+        self.assertEqual(1, client._send(b'\x00'))
+        self.assertEqual(b'\x00', client._recv(1))
+
+        # connect/disconnect
+        self.assertTrue(client.connect())
+        client.close()
+
+        # already closed socket
+        client.socket = False
+        client.close()
+
+        self.assertEqual("ModbusTlsClient(localhost:802)", str(client))
+
+    def testTlsClientConnect(self):
+        ''' Test the tls client connection method'''
+        with patch.object(ssl.SSLSocket, 'connect') as mock_method:
+            client = ModbusTlsClient()
+            self.assertTrue(client.connect())
+
+        with patch.object(socket, 'create_connection') as mock_method:
+            mock_method.side_effect = socket.error()
+            client = ModbusTlsClient()
+            self.assertFalse(client.connect())
+
+    def testTlsClientSend(self):
+        ''' Test the tls client send method'''
+        client = ModbusTlsClient()
+        self.assertRaises(ConnectionException, lambda: client._send(None))
+
+        client.socket = mockSocket()
+        self.assertEqual(0, client._send(None))
+        self.assertEqual(4, client._send('1234'))
+
+    def testTlsClientRecv(self):
+        ''' Test the tls client receive method'''
+        client = ModbusTlsClient()
+        self.assertRaises(ConnectionException, lambda: client._recv(1024))
+
+        client.socket = mockSocket()
+        self.assertEqual(b'', client._recv(0))
+        self.assertEqual(b'\x00' * 4, client._recv(4))
+
+        mock_socket = MagicMock()
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
+        client.socket = mock_socket
+        client.timeout = 1
+        self.assertEqual(b'\x00\x01\x02', client._recv(3))
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
+        self.assertEqual(b'\x00\x01', client._recv(2))
+
+    def testTlsClientRpr(self):
+        client = ModbusTlsClient()
+        rep = "<{} at {} socket={}, ipaddr={}, port={}, sslctx={}, " \
+            "timeout={}>".format(
+            client.__class__.__name__, hex(id(client)), client.socket,
+            client.host, client.port, client.sslctx, client.timeout
+        )
+        self.assertEqual(repr(client), rep)
+
+    def testTlsClientRegister(self):
+        class CustomeRequest:
+            function_code = 79
+        client = ModbusTlsClient()
+        client.framer = Mock()
+        client.register(CustomeRequest)
+        assert client.framer.decoder.register.called_once_with(CustomeRequest)
+
     # -----------------------------------------------------------------------#
     # Test Serial Client
     # -----------------------------------------------------------------------#


### PR DESCRIPTION
Modbus.org released MODBUS/TCP Security Protocol Specification [1],
which focuses variant of the Mobdbus/TCP protocol utilizing Transport
Layer Security (TLS). This patch enables the Modbus TCP over TLS feature
for ModbusTcpClient with the Python builtin module ssl - TLS/SSL wrapper
for socket objects.

[1]: http://modbus.org/docs/MB-TCP-Security-v21_2018-07-24.pdf

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
