### PR TITLE
Drop python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ matrix:
   - os: linux
     python: "2.7"
   - os: linux
-    python: "3.4"
-  - os: linux
     python: "3.5"
   - os: linux
     python: "3.6"

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37, pypy
+envlist = py27, py35, py36, py37, pypy
 
 [testenv]
 deps = -r requirements-tests.txt


### PR DESCRIPTION
Python 3.4 is EoL and has an easy upgrade path to 3.5+. Support was dropped in Twisted 19.7.0, which is causing Travis to fail pymodbus tests for 3.4 e.g. https://travis-ci.org/riptideio/pymodbus/jobs/582270191 for #439.

As for distro versions, no issue:
Debian stretch (oldstable): 3.5.3
Debian buster (stable): 3.7.3
RHEL 8: 3.6
Fedora 28: 3.6
Fedora 30: 3.7
FreeBSD 11/12: 3.6.8