### PR TITLE
Support multiple Python versions to fix test error from PR #400

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -1,5 +1,6 @@
 import socket
 import select
+import serial
 import time
 import sys
 from functools import partial

--- a/pymodbus/server/asyncio.py
+++ b/pymodbus/server/asyncio.py
@@ -62,7 +62,10 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
             self.framer = self.server.framer(self.server.decoder, client=None)
 
             # schedule the connection handler on the event loop
-            self.handler_task = asyncio.create_task(self.handle())
+            if PYTHON_VERSION >= (3, 7):
+                self.handler_task = asyncio.create_task(self.handle())
+            else:
+                self.handler_task = asyncio.ensure_future(self.handle())
         except Exception as ex: # pragma: no cover
             _logger.debug("Datastore unable to fulfill request: "
                           "%s; %s", ex, traceback.format_exc())

--- a/pymodbus/server/asyncio.py
+++ b/pymodbus/server/asyncio.py
@@ -421,7 +421,7 @@ class ModbusTcpServer:
 
     def server_close(self):
         for k,v in self.active_connections.items():
-            _logger.warning(f"aborting active session {k}")
+            _logger.warning("aborting active session {}".format(k))
             v.handler_task.cancel()
         self.active_connections = {}
         self.server.close()

--- a/test/test_server_asyncio.py
+++ b/test/test_server_asyncio.py
@@ -73,7 +73,8 @@ class AsyncioServerTest(asynctest.TestCase):
         self.loop = asynctest.Mock(self.loop)
         server = yield from StartTcpServer(context=self.context,loop=self.loop,identity=identity)
         self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-        self.loop.create_server.assert_called_once()
+        if PYTHON_VERSION >= (3, 6):
+            self.loop.create_server.assert_called_once()
 
     @pytest.mark.skipif(PYTHON_VERSION < (3, 7), reason="requires python3.7 or above")
     @asyncio.coroutine
@@ -134,7 +135,8 @@ class AsyncioServerTest(asynctest.TestCase):
             # if this unit test fails on a machine, see if increasing the sleep time makes a difference, if it does
             # blame author for a fix
 
-            process.assert_called_once()
+            if PYTHON_VERSION >= (3, 6):
+                process.assert_called_once()
             self.assertTrue( process.call_args[1]["data"] == data )
             server.server_close()
 
@@ -409,7 +411,8 @@ class AsyncioServerTest(asynctest.TestCase):
         self.loop = asynctest.Mock(self.loop)
         server = yield from StartUdpServer(context=self.context,loop=self.loop,identity=identity)
         self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-        self.loop.create_datagram_endpoint.assert_called_once()
+        if PYTHON_VERSION >= (3, 6):
+            self.loop.create_datagram_endpoint.assert_called_once()
 
     # async def testUdpServerServeNoDefer(self):
     #     ''' Test StartUdpServer without deferred start - NOT IMPLEMENTED - this test is hard to do without additional
@@ -473,7 +476,8 @@ class AsyncioServerTest(asynctest.TestCase):
             yield from asyncio.sleep(0.1)
             process.seal()
 
-            process.assert_called_once()
+            if PYTHON_VERSION >= (3, 6):
+                process.assert_called_once()
             self.assertTrue( process.call_args[1]["data"] == b"12345" )
 
             server.server_close()
@@ -511,7 +515,8 @@ class AsyncioServerTest(asynctest.TestCase):
 
         yield from asyncio.sleep(0.1)
 
-        received.assert_called_once()
+        if PYTHON_VERSION >= (3, 6):
+            received.assert_called_once()
         self.assertEqual(received.call_args[0][0], data)
 
         server.server_close()

--- a/test/test_server_asyncio.py
+++ b/test/test_server_asyncio.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from pymodbus.compat import IS_PYTHON3
+from pymodbus.compat import IS_PYTHON3, PYTHON_VERSION
 import pytest
 import asynctest
 import asyncio
@@ -94,7 +94,10 @@ class AsyncioServerTest(asynctest.TestCase):
     def testTcpServerServeForeverTwice(self):
         ''' Call on serve_forever() twice should result in a runtime error '''
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0), loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with self.assertRaises(RuntimeError):
             yield from server.serve_forever()
@@ -105,7 +108,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test data sent on socket is received by internals - doesn't not process data '''
         data = b'\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket', new_callable=Mock) as process:
         # process = server.framer.processIncomingPacket = Mock()
@@ -136,7 +142,10 @@ class AsyncioServerTest(asynctest.TestCase):
         data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01" # unit 1, read register
         expected_response = b'\x01\x00\x00\x00\x00\x05\x01\x03\x02\x00\x11' # value of 17 as per context
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
 
         random_port = server.server.sockets[0].getsockname()[1] # get the random server port
@@ -172,7 +181,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test tcp stream interruption '''
         data = b"\x01\x00\x00\x00\x00\x06\x01\x01\x00\x00\x00\x01"
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
 
         random_port = server.server.sockets[0].getsockname()[1] # get the random server port
@@ -202,7 +214,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test server_close() while there are active TCP connections '''
         data = b"\x01\x00\x00\x00\x00\x06\x01\x01\x00\x00\x00\x01"
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
 
         random_port = server.server.sockets[0].getsockname()[1] # get the random server port
@@ -231,7 +246,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Sending garbage data on a TCP socket should drop the connection '''
         garbage = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',
                    new_callable=lambda : Mock(side_effect=Exception)) as process:
@@ -267,7 +285,10 @@ class AsyncioServerTest(asynctest.TestCase):
         context = ModbusServerContext(slaves={0x01: self.store, 0x02: self.store  }, single=False)
         data = b"\x01\x00\x00\x00\x00\x06\x05\x03\x00\x00\x00\x01" # get slave 5 function 3 (holding register)
         server = yield from StartTcpServer(context=context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         connect, receive, eof = self.loop.create_future(),self.loop.create_future(),self.loop.create_future()
         received_data = None
@@ -299,7 +320,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test sending garbage data on a TCP socket should drop the connection '''
         data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"  # get slave 5 function 3 (holding register)
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch("pymodbus.register_read_message.ReadHoldingRegistersRequest.execute",
                    side_effect=NoSuchSlaveException):
@@ -335,7 +359,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test sending garbage data on a TCP socket should drop the connection '''
         data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"  # get slave 5 function 3 (holding register)
         server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch("pymodbus.register_read_message.ReadHoldingRegistersRequest.execute",
                    side_effect=Exception):
@@ -401,7 +428,10 @@ class AsyncioServerTest(asynctest.TestCase):
     def testUdpServerServeForeverClose(self):
         ''' Test StartUdpServer serve_forever() method '''
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0), loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
 
         self.assertTrue(asyncio.isfuture(server.on_connection_terminated))
@@ -416,7 +446,10 @@ class AsyncioServerTest(asynctest.TestCase):
         identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0),
                                       loop=self.loop,identity=identity)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with self.assertRaises(RuntimeError):
             yield from server.serve_forever()
@@ -426,7 +459,10 @@ class AsyncioServerTest(asynctest.TestCase):
     def testUdpServerReceiveData(self):
         ''' Test that the sending data on datagram socket gets data pushed to framer '''
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',new_callable=Mock) as process:
 
@@ -445,7 +481,10 @@ class AsyncioServerTest(asynctest.TestCase):
         identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
         data = b'x\01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0))
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         random_port = server.protocol._sock.getsockname()[1]
         received = server.endpoint.datagram_received = Mock(wraps=server.endpoint.datagram_received)
@@ -483,7 +522,10 @@ class AsyncioServerTest(asynctest.TestCase):
         data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01" # unit 1, read register
         expected_response = b'\x01\x00\x00\x00\x00\x05\x01\x03\x02\x00\x11' # value of 17 as per context
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
 
         random_port = server.protocol._sock.getsockname()[1]
@@ -517,7 +559,10 @@ class AsyncioServerTest(asynctest.TestCase):
         ''' Test sending garbage data on a TCP socket should drop the connection '''
         garbage = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
         server = yield from StartUdpServer(context=self.context,address=("127.0.0.1", 0),loop=self.loop)
-        server_task = asyncio.create_task(server.serve_forever())
+        if PYTHON_VERSION >= (3, 7):
+            server_task = asyncio.create_task(server.serve_forever())
+        else:
+            server_task = asyncio.ensure_future(server.serve_forever())
         yield from server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',
                    new_callable=lambda: Mock(side_effect=Exception)) as process:

--- a/test/test_server_asyncio.py
+++ b/test/test_server_asyncio.py
@@ -75,6 +75,7 @@ class AsyncioServerTest(asynctest.TestCase):
         self.assertEqual(server.control.Identity.VendorName, 'VendorName')
         self.loop.create_server.assert_called_once()
 
+    @pytest.mark.skipif(PYTHON_VERSION < (3, 7), reason="requires python3.7 or above")
     @asyncio.coroutine
     def testTcpServerServeNoDefer(self):
         ''' Test StartTcpServer without deferred start (immediate execution of server) '''
@@ -82,6 +83,7 @@ class AsyncioServerTest(asynctest.TestCase):
             server = yield from StartTcpServer(context=self.context,address=("127.0.0.1", 0), loop=self.loop, defer_start=False)
             serve.assert_awaited()
 
+    @pytest.mark.skipif(PYTHON_VERSION < (3, 7), reason="requires python3.7 or above")
     @asyncio.coroutine
     def testTcpServerServeForever(self):
         ''' Test StartTcpServer serve_forever() method '''
@@ -416,6 +418,7 @@ class AsyncioServerTest(asynctest.TestCase):
     #     server = yield from StartUdpServer(address=("127.0.0.1", 0), loop=self.loop, defer_start=False)
     #     server.server.serve_forever.assert_awaited()
 
+    @pytest.mark.skipif(PYTHON_VERSION < (3, 7), reason="requires python3.7 or above")
     @asyncio.coroutine
     def testUdpServerServeForeverStart(self):
         ''' Test StartUdpServer serve_forever() method '''


### PR DESCRIPTION
Here are the commits to fix the test error from PR #400
* server/asyncio.py: Create server with appropriate args and environment
* Create asyncio task with appropriate method and environment
* test: Make serve_forever() test only with Python 3.7+
* server/asyncio.py: Fix format string for older Python
* test: Make assert_called_once() test only with Python 3.6+

There is still one **SyntaxError** error from `yield from` in test with Python 2.7, but have no idea how to skip the test_server_asyncio.py for it.  The good new is Python 2.7 will be end of support at the end of this year.