### PR TITLE
Add TLS feature for Modbus synchronous

### DIFF
--- a/examples/common/synchronous_server.py
+++ b/examples/common/synchronous_server.py
@@ -12,6 +12,7 @@ twisted is just not feasible. What follows is an example of its use:
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.server.sync import StartTcpServer
+from pymodbus.server.sync import StartTlsServer
 from pymodbus.server.sync import StartUdpServer
 from pymodbus.server.sync import StartSerialServer
 
@@ -116,6 +117,10 @@ def run_server():
     # TCP with different framer
     # StartTcpServer(context, identity=identity,
     #                framer=ModbusRtuFramer, address=("0.0.0.0", 5020))
+
+    # TLS
+    # StartTlsServer(context, identity=identity, certfile="server.crt",
+    #                keyfile="server.key", address=("0.0.0.0", 8020))
 
     # Udp:
     # StartUdpServer(context, identity=identity, address=("0.0.0.0", 5020))

--- a/examples/contrib/modbus_tls_client.py
+++ b/examples/contrib/modbus_tls_client.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""
+Simple Modbus TCP over TLS client
+---------------------------------------------------------------------------
+
+This is a simple example of writing a modbus TCP over TLS client that uses
+Python builtin module ssl - TLS/SSL wrapper for socket objects for the TLS
+feature.
+"""
+# -------------------------------------------------------------------------- #
+# import neccessary libraries
+# -------------------------------------------------------------------------- #
+import ssl
+from pymodbus.client.sync import ModbusTlsClient
+
+# -------------------------------------------------------------------------- #
+# the TLS detail security can be set in SSLContext which is the context here
+# -------------------------------------------------------------------------- #
+context = ssl.create_default_context()
+context.options |= ssl.OP_NO_SSLv2
+context.options |= ssl.OP_NO_SSLv3
+context.options |= ssl.OP_NO_TLSv1
+context.options |= ssl.OP_NO_TLSv1_1
+
+# -------------------------------------------------------------------------- #
+# pass SSLContext which is the context here to ModbusTcpClient()
+# -------------------------------------------------------------------------- #
+client = ModbusTlsClient('test.host.com', 8020, sslctx=context)
+client.connect()
+
+result = client.read_coils(1, 8)
+print(result.bits)
+
+client.close()

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -2,6 +2,7 @@ import socket
 import select
 import serial
 import time
+import ssl
 import sys
 from functools import partial
 from pymodbus.constants import Defaults
@@ -13,6 +14,7 @@ from pymodbus.transaction import FifoTransactionManager
 from pymodbus.transaction import DictTransactionManager
 from pymodbus.transaction import ModbusSocketFramer, ModbusBinaryFramer
 from pymodbus.transaction import ModbusAsciiFramer, ModbusRtuFramer
+from pymodbus.transaction import ModbusTlsFramer
 from pymodbus.client.common import ModbusClientMixin
 
 # --------------------------------------------------------------------------- #
@@ -296,6 +298,116 @@ class ModbusTcpClient(BaseModbusClient):
             "<{} at {} socket={self.socket}, ipaddr={self.host}, "
             "port={self.port}, timeout={self.timeout}>"
         ).format(self.__class__.__name__, hex(id(self)), self=self)
+
+# --------------------------------------------------------------------------- #
+# Modbus TLS Client Transport Implementation
+# --------------------------------------------------------------------------- #
+
+
+class ModbusTlsClient(ModbusTcpClient):
+    """ Implementation of a modbus tls client
+    """
+
+    def __init__(self, host='localhost', port=Defaults.TLSPort, sslctx=None,
+        framer=ModbusTlsFramer, **kwargs):
+        """ Initialize a client instance
+
+        :param host: The host to connect to (default localhost)
+        :param port: The modbus port to connect to (default 802)
+        :param sslctx: The SSLContext to use for TLS (default None and auto create)
+        :param source_address: The source address tuple to bind to (default ('', 0))
+        :param timeout: The timeout to use for this socket (default Defaults.Timeout)
+        :param framer: The modbus framer to use (default ModbusSocketFramer)
+
+        .. note:: The host argument will accept ipv4 and ipv6 hosts
+        """
+        self.sslctx = sslctx
+        if self.sslctx is None:
+            self.sslctx = ssl.create_default_context()
+            # According to MODBUS/TCP Security Protocol Specification, it is
+            # TLSv2 at least
+            self.sslctx.options |= ssl.OP_NO_TLSv1_1
+            self.sslctx.options |= ssl.OP_NO_TLSv1
+            self.sslctx.options |= ssl.OP_NO_SSLv3
+            self.sslctx.options |= ssl.OP_NO_SSLv2
+        ModbusTcpClient.__init__(self, host, port, framer, **kwargs)
+
+    def connect(self):
+        """ Connect to the modbus tls server
+
+        :returns: True if connection succeeded, False otherwise
+        """
+        if self.socket: return True
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.bind(self.source_address)
+            self.socket = self.sslctx.wrap_socket(sock, server_side=False,
+                                                  server_hostname=self.host)
+            self.socket.settimeout(self.timeout)
+            self.socket.connect((self.host, self.port))
+        except socket.error as msg:
+            _logger.error('Connection to (%s, %s) '
+                          'failed: %s' % (self.host, self.port, msg))
+            self.close()
+        return self.socket is not None
+
+    def _recv(self, size):
+        """ Reads data from the underlying descriptor
+
+        :param size: The number of bytes to read
+        :return: The bytes read
+        """
+        if not self.socket:
+            raise ConnectionException(self.__str__())
+
+        # socket.recv(size) waits until it gets some data from the host but
+        # not necessarily the entire response that can be fragmented in
+        # many packets.
+        # To avoid the splitted responses to be recognized as invalid
+        # messages and to be discarded, loops socket.recv until full data
+        # is received or timeout is expired.
+        # If timeout expires returns the read data, also if its length is
+        # less than the expected size.
+        timeout = self.timeout
+
+        # If size isn't specified read 1 byte at a time.
+        if size is None:
+            recv_size = 1
+        else:
+            recv_size = size
+
+        data = b''
+        time_ = time.time()
+        end = time_ + timeout
+        while recv_size > 0:
+            data += self.socket.recv(recv_size)
+            time_ = time.time()
+
+            # If size isn't specified continue to read until timeout expires.
+            if size:
+                recv_size = size - len(data)
+
+            # Timeout is reduced also if some data has been received in order
+            # to avoid infinite loops when there isn't an expected response
+            # size and the slave sends noisy data continuosly.
+            if time_ > end:
+                break
+
+        return data
+
+    def __str__(self):
+        """ Builds a string representation of the connection
+
+        :returns: The string representation
+        """
+        return "ModbusTlsClient(%s:%s)" % (self.host, self.port)
+
+    def __repr__(self):
+        return (
+            "<{} at {} socket={self.socket}, ipaddr={self.host}, "
+            "port={self.port}, sslctx={self.sslctx}, timeout={self.timeout}>"
+        ).format(self.__class__.__name__, hex(id(self)), self=self)
+
 
 # --------------------------------------------------------------------------- #
 # Modbus UDP Client Transport Implementation
@@ -594,5 +706,5 @@ class ModbusSerialClient(BaseModbusClient):
 
 
 __all__ = [
-    "ModbusTcpClient", "ModbusUdpClient", "ModbusSerialClient"
+    "ModbusTcpClient", "ModbusTlsClient", "ModbusUdpClient", "ModbusSerialClient"
 ]

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -15,6 +15,10 @@ class Defaults(Singleton):
 
        The default modbus tcp server port (502)
 
+    .. attribute:: TLSPort
+
+       The default modbus tcp over tls server port (802)
+
     .. attribute:: Retries
 
        The default number of times a client should retry the given
@@ -99,6 +103,7 @@ class Defaults(Singleton):
 
     '''
     Port                = 502
+    TLSPort             = 802
     Retries             = 3
     RetryOnEmpty        = False
     Timeout             = 3

--- a/pymodbus/framer/__init__.py
+++ b/pymodbus/framer/__init__.py
@@ -8,6 +8,8 @@ FRAME_HEADER = 'BB'
 # Transaction Id, Protocol ID, Length, Unit ID, Function Code
 SOCKET_FRAME_HEADER = BYTE_ORDER + 'HHH' + FRAME_HEADER
 
+# Function Code
+TLS_FRAME_HEADER = BYTE_ORDER + 'B'
 
 class ModbusFramer(IModbusFramer):
     """

--- a/pymodbus/framer/tls_framer.py
+++ b/pymodbus/framer/tls_framer.py
@@ -1,0 +1,185 @@
+import struct
+from pymodbus.exceptions import ModbusIOException
+from pymodbus.exceptions import InvalidMessageReceivedException
+from pymodbus.utilities import hexlify_packets
+from pymodbus.framer import ModbusFramer, TLS_FRAME_HEADER
+
+# --------------------------------------------------------------------------- #
+# Logging
+# --------------------------------------------------------------------------- #
+import logging
+_logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Modbus TLS Message
+# --------------------------------------------------------------------------- #
+
+
+class ModbusTlsFramer(ModbusFramer):
+    """ Modbus TLS Frame controller
+
+    No prefix MBAP header before decrypted PDU is used as a message frame for
+    Modbus Security Application Protocol.  It allows us to easily separate
+    decrypted messages which is PDU as follows:
+
+        [ Function Code] [ Data ]
+          1b               Nb
+    """
+
+    def __init__(self, decoder, client=None):
+        """ Initializes a new instance of the framer
+
+        :param decoder: The decoder factory implementation to use
+        """
+        self._buffer = b''
+        self._header = {}
+        self._hsize = 0x0
+        self.decoder = decoder
+        self.client = client
+
+    # ----------------------------------------------------------------------- #
+    # Private Helper Functions
+    # ----------------------------------------------------------------------- #
+    def checkFrame(self):
+        """
+        Check and decode the next frame Return true if we were successful
+        """
+        if self.isFrameReady():
+            # we have at least a complete message, continue
+            if len(self._buffer) - self._hsize >= 1:
+                return True
+        # we don't have enough of a message yet, wait
+        return False
+
+    def advanceFrame(self):
+        """ Skip over the current framed message
+        This allows us to skip over the current message after we have processed
+        it or determined that it contains an error. It also has to reset the
+        current frame header handle
+        """
+        self._buffer = b''
+        self._header = {}
+
+    def isFrameReady(self):
+        """ Check if we should continue decode logic
+        This is meant to be used in a while loop in the decoding phase to let
+        the decoder factory know that there is still data in the buffer.
+
+        :returns: True if ready, False otherwise
+        """
+        return len(self._buffer) > self._hsize
+
+    def addToFrame(self, message):
+        """ Adds new packet data to the current frame buffer
+
+        :param message: The most recent packet
+        """
+        self._buffer += message
+
+    def getFrame(self):
+        """ Return the next frame from the buffered data
+
+        :returns: The next full frame buffer
+        """
+        return self._buffer[self._hsize:]
+
+    def populateResult(self, result):
+        """
+        Populates the modbus result with the transport specific header
+        information (no header before PDU in decrypted message)
+
+        :param result: The response packet
+        """
+        return
+
+    # ----------------------------------------------------------------------- #
+    # Public Member Functions
+    # ----------------------------------------------------------------------- #
+    def decode_data(self, data):
+        if len(data) > self._hsize:
+            (fcode,) = struct.unpack(TLS_FRAME_HEADER, data[0:self._hsize+1])
+            return dict(fcode=fcode)
+        return dict()
+
+    def processIncomingPacket(self, data, callback, unit, **kwargs):
+        """
+        The new packet processing pattern
+
+        This takes in a new request packet, adds it to the current
+        packet stream, and performs framing on it. That is, checks
+        for complete messages, and once found, will process all that
+        exist.  This handles the case when we read N + 1 or 1 // N
+        messages at a time instead of 1.
+
+        The processed and decoded messages are pushed to the callback
+        function to process and send.
+
+        :param data: The new packet data
+        :param callback: The function to send results to
+        :param unit: Process if unit id matches, ignore otherwise (could be a
+               list of unit ids (server) or single unit id(client/server)
+        :param single: True or False (If True, ignore unit address validation)
+        :return:
+        """
+        if not isinstance(unit, (list, tuple)):
+            unit = [unit]
+        # no unit id for Modbus Security Application Protocol
+        single = kwargs.get("single", True)
+        _logger.debug("Processing: " + hexlify_packets(data))
+        self.addToFrame(data)
+
+        if self.isFrameReady():
+            if self.checkFrame():
+                if self._validate_unit_id(unit, single):
+                    self._process(callback)
+                else:
+                    _logger.debug("Not in valid unit id - {}, "
+                                  "ignoring!!".format(unit))
+                    self.resetFrame()
+            else:
+                _logger.debug("Frame check failed, ignoring!!")
+                self.resetFrame()
+
+    def _process(self, callback, error=False):
+        """
+        Process incoming packets irrespective error condition
+        """
+        data = self.getRawFrame() if error else self.getFrame()
+        result = self.decoder.decode(data)
+        if result is None:
+            raise ModbusIOException("Unable to decode request")
+        elif error and result.function_code < 0x80:
+            raise InvalidMessageReceivedException(result)
+        else:
+            self.populateResult(result)
+            self.advanceFrame()
+            callback(result)  # defer or push to a thread?
+
+    def resetFrame(self):
+        """
+        Reset the entire message frame.
+        This allows us to skip ovver errors that may be in the stream.
+        It is hard to know if we are simply out of sync or if there is
+        an error in the stream as we have no way to check the start or
+        end of the message (python just doesn't have the resolution to
+        check for millisecond delays).
+        """
+        self._buffer = b''
+
+    def getRawFrame(self):
+        """
+        Returns the complete buffer
+        """
+        return self._buffer
+
+    def buildPacket(self, message):
+        """ Creates a ready to send modbus packet
+
+        :param message: The populated request/response to send
+        """
+        data = message.encode()
+        packet = struct.pack(TLS_FRAME_HEADER, message.function_code)
+        packet += data
+        return packet
+
+# __END__

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -14,6 +14,7 @@ from pymodbus.constants import Defaults
 from pymodbus.framer.ascii_framer import ModbusAsciiFramer
 from pymodbus.framer.rtu_framer import ModbusRtuFramer
 from pymodbus.framer.socket_framer import ModbusSocketFramer
+from pymodbus.framer.tls_framer import ModbusTlsFramer
 from pymodbus.framer.binary_framer import ModbusBinaryFramer
 from pymodbus.utilities import hexlify_packets, ModbusTransactionState
 from pymodbus.compat import iterkeys, byte2int
@@ -78,6 +79,8 @@ class ModbusTransactionManager(object):
             self.base_adu_size = 7  # start(1)+ Address(2), LRC(2) + end(2)
         elif isinstance(self.client.framer, ModbusBinaryFramer):
             self.base_adu_size = 5  # start(1) + Address(1), CRC(2) + end(1)
+        elif isinstance(self.client.framer, ModbusTlsFramer):
+            self.base_adu_size = 0  # no header and footer
         else:
             self.base_adu_size = -1
 
@@ -91,7 +94,8 @@ class ModbusTransactionManager(object):
         """ Returns the length of the Modbus Exception Response according to
         the type of Framer.
         """
-        if isinstance(self.client.framer, ModbusSocketFramer):
+        if isinstance(self.client.framer, (ModbusSocketFramer,
+                                           ModbusTlsFramer)):
             return self.base_adu_size + 2  # Fcode(1), ExcecptionCode(1)
         elif isinstance(self.client.framer, ModbusAsciiFramer):
             return self.base_adu_size + 4  # Fcode(2), ExcecptionCode(2)
@@ -459,6 +463,6 @@ class FifoTransactionManager(ModbusTransactionManager):
 __all__ = [
     "FifoTransactionManager",
     "DictTransactionManager",
-    "ModbusSocketFramer", "ModbusRtuFramer",
+    "ModbusSocketFramer", "ModbusTlsFramer", "ModbusRtuFramer",
     "ModbusAsciiFramer", "ModbusBinaryFramer",
 ]


### PR DESCRIPTION
Modbus.org released MODBUS/TCP Security Protocol Specification [1],
which focuses variant of the Mobdbus/TCP protocol utilizing Transport
Layer Security (TLS). This patch enables the Modbus over TLS feature as
ModbusTlsClient with the Python builtin module ssl - TLS/SSL wrapper for
socket objects.

[1]: http://modbus.org/docs/MB-TCP-Security-v21_2018-07-24.pdf

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
