### PR TITLE
Add option to repl allowing Modbus RTU framing on a TCP socket

### DIFF
--- a/pymodbus/repl/README.md
+++ b/pymodbus/repl/README.md
@@ -41,6 +41,7 @@ Usage: pymodbus.console tcp [OPTIONS]
 Options:
   --host TEXT     Modbus TCP IP
   --port INTEGER  Modbus TCP port
+  --framer TEXT   Override the default packet framer tcp|rtu
   --help          Show this message and exit.
 
 

--- a/pymodbus/repl/main.py
+++ b/pymodbus/repl/main.py
@@ -250,9 +250,19 @@ def main(ctx, verbose):
     type=int,
     help="Modbus TCP port",
 )
-def tcp(ctx, host, port):
+@click.option(
+    "--framer",
+    default='tcp',
+    type=str,
+    help="Override the default packet framer tcp|rtu",
+)
+def tcp(ctx, host, port, framer):
     from pymodbus.repl.client import ModbusTcpClient
-    client = ModbusTcpClient(host=host, port=port)
+    kwargs = dict(host=host, port=port)
+    if framer == 'rtu':
+        from pymodbus.framer.rtu_framer import ModbusRtuFramer
+        kwargs['framer'] = ModbusRtuFramer
+    client = ModbusTcpClient(**kwargs)
     cli(client)
 
 


### PR DESCRIPTION
The pymodbus.console tcp support does not allow RTU framing. This adds a command line option to enable it.


