### PR TITLE
Add handle local echo option

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -539,6 +539,7 @@ class ModbusSerialClient(BaseModbusClient):
         :param timeout: The timeout between serial requests (default 3s)
         :param strict:  Use Inter char timeout for baudrates <= 19200 (adhere
         to modbus standards)
+        :param handle_local_echo: Handle local echo of the USB-to-RS485 adaptor
         """
         self.method = method
         self.socket = None
@@ -553,6 +554,7 @@ class ModbusSerialClient(BaseModbusClient):
         self.timeout = kwargs.get('timeout',  Defaults.Timeout)
         self._strict = kwargs.get("strict", True)
         self.last_frame_end = None
+        self.handle_local_echo = kwargs.get("handle_local_echo", False)
         if self.method == "rtu":
             if self.baudrate > 19200:
                 self.silent_interval = 1.75 / 1000  # ms

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -228,6 +228,10 @@ class ModbusTransactionManager(object):
                 _logger.debug("Changing transaction state from 'SENDING' "
                               "to 'WAITING FOR REPLY'")
                 self.client.state = ModbusTransactionState.WAITING_FOR_REPLY
+            if self.client.handle_local_echo:
+                local_echo_packet = self._recv(size, full)
+                if local_echo_packet != packet:
+                    return b'', "Wrong local echo"
             result = self._recv(response_length, full)
             if _logger.isEnabledFor(logging.DEBUG):
                     _logger.debug("RECV: " + hexlify_packets(result))


### PR DESCRIPTION
Hello!

We're at [b4cksp4c3 hackspace](https://github.com/b4ck5p4c3/pymodbus) have found out that we need handling local echo option. The logic is simple and similar to [minimalmodbus local echo handling logic](https://github.com/pyhys/minimalmodbus/blob/master/docs/troubleshooting.rst#local-echo).
Is it makes sense to upstream the changes?

While for example at libmodbus discussion https://github.com/stephane/libmodbus/issues/380 we have found out that most of the devices should be able to manage local echo internally, we definitely had problems with our DIY max13487e-based device for the RPi. After that, we managed to find [additional info from SO](https://stackoverflow.com/questions/21148655/python-pyserial-with-auto-rts-through-half-duplex-rs-485-breakout-board-using-be#comment42075876_21148655), that our scheme is missing a pull-up resistor on the RO. And we managed to handle it on the hardware side for our case. But it wasn't documented explicitly about the resistor in the datasheet and wasn't obvious for us.

What do you say, is proposing the changes make sense? 

P.S. I've used the `master` branch for branching, should I rebase it to `dev` for the PR? The actual commit is the only one: 244b42e