### PR TITLE
Fix #477

### DIFF
--- a/pymodbus/server/asyncio.py
+++ b/pymodbus/server/asyncio.py
@@ -244,12 +244,12 @@ class ModbusConnectedRequestHandler(ModbusBaseRequestHandler,asyncio.Protocol):
 
         self.client_address = transport.get_extra_info('peername')
         self.server.active_connections[self.client_address] = self
-        _logger.debug("TCP client connection established [%s:%s]" % self.client_address)
+        _logger.debug("TCP client connection established [%s]" % self.client_address)
 
     def connection_lost(self, exc):
         """ asyncio.BaseProtocol: Called when the connection is lost or closed."""
         super().connection_lost(exc)
-        _logger.debug("TCP client disconnected [%s:%s]" % self.client_address)
+        _logger.debug("TCP client disconnected [%s]" % self.client_address)
         if self.client_address in self.server.active_connections:
             self.server.active_connections.pop(self.client_address)
 


### PR DESCRIPTION

Fix error when connection to the asyncio client and logging is in "debug" verbosity level.

There may be other places where the same problem occurs. It would be great if the type of variables were somehow indicated (see #476). This would avoid this kind of bugs.