### PR TITLE
Refactor/DRY: use `use_hexlify_packets`

### DIFF
--- a/pymodbus/client/asynchronous/async_io/__init__.py
+++ b/pymodbus/client/asynchronous/async_io/__init__.py
@@ -7,7 +7,7 @@ import functools
 import ssl
 from pymodbus.exceptions import ConnectionException
 from pymodbus.client.asynchronous.mixins import AsyncModbusClientMixin
-from pymodbus.compat import byte2int
+from pymodbus.utilities import hexlify_packets
 from pymodbus.transaction import FifoTransactionManager
 import logging
 
@@ -137,7 +137,7 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """
         request.transaction_id = self.transaction.getNextTID()
         packet = self.framer.buildPacket(request)
-        _logger.debug("send: " + " ".join([hex(byte2int(x)) for x in packet]))
+        _logger.debug("send: " + hexlify_packets(packet))
         self.write_transport(packet)
         return self._buildResponse(request.transaction_id)
 
@@ -146,7 +146,7 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
 
         :param data: The data returned from the server
         '''
-        _logger.debug("recv: " + " ".join([hex(byte2int(x)) for x in data]))
+        _logger.debug("recv: " + hexlify_packets(data))
         unit = self.framer.decode_data(data).get("unit", 0)
         self.framer.processIncomingPacket(data, self._handleResponse, unit=unit)
 

--- a/pymodbus/client/asynchronous/tornado/__init__.py
+++ b/pymodbus/client/asynchronous/tornado/__init__.py
@@ -18,7 +18,7 @@ from tornado.iostream import BaseIOStream
 from pymodbus.client.asynchronous.mixins import (AsyncModbusClientMixin,
                                                  AsyncModbusSerialClientMixin)
 from pymodbus.exceptions import ConnectionException
-from pymodbus.compat import byte2int
+from pymodbus.utilities import hexlify_packets
 
 LOGGER = logging.getLogger(__name__)
 
@@ -74,7 +74,7 @@ class BaseTornadoClient(AsyncModbusClientMixin):
 
         if not data:
             return
-        LOGGER.debug("recv: " + " ".join([hex(byte2int(x)) for x in data]))
+        LOGGER.debug("recv: " + hexlify_packets(data))
         unit = self.framer.decode_data(data).get("unit", 0)
         self.framer.processIncomingPacket(data, self._handle_response, unit=unit)
 
@@ -86,7 +86,7 @@ class BaseTornadoClient(AsyncModbusClientMixin):
         """
         request.transaction_id = self.transaction.getNextTID()
         packet = self.framer.buildPacket(request)
-        LOGGER.debug("send: " + " ".join([hex(byte2int(x)) for x in packet]))
+        LOGGER.debug("send: " + hexlify_packets(packet))
         self.stream.write(packet)
         return self._build_response(request.transaction_id)
 
@@ -174,7 +174,7 @@ class BaseTornadoSerialClient(AsyncModbusSerialClientMixin):
                 if waiting:
                     data = self.stream.connection.read(waiting)
                     LOGGER.debug(
-                        "recv: " + " ".join([hex(byte2int(x)) for x in data]))
+                        "recv: " + hexlify_packets(data))
                     unit = self.framer.decode_data(data).get("uid", 0)
                     self.framer.processIncomingPacket(
                         data,
@@ -185,7 +185,7 @@ class BaseTornadoSerialClient(AsyncModbusSerialClientMixin):
                     break
 
         packet = self.framer.buildPacket(request)
-        LOGGER.debug("send: " + " ".join([hex(byte2int(x)) for x in packet]))
+        LOGGER.debug("send: " + hexlify_packets(packet))
         self.stream.write(packet, callback=callback)
         f = self._build_response(request.transaction_id)
         return f

--- a/pymodbus/client/asynchronous/twisted/__init__.py
+++ b/pymodbus/client/asynchronous/twisted/__init__.py
@@ -40,7 +40,7 @@ from pymodbus.factory import ClientDecoder
 from pymodbus.client.asynchronous.mixins import AsyncModbusClientMixin
 from pymodbus.transaction import FifoTransactionManager, DictTransactionManager
 from pymodbus.transaction import ModbusSocketFramer, ModbusRtuFramer
-from pymodbus.compat import byte2int
+from pymodbus.utilities import hexlify_packets
 from twisted.python.failure import Failure
 
 
@@ -109,7 +109,7 @@ class ModbusClientProtocol(protocol.Protocol,
         """
         request.transaction_id = self.transaction.getNextTID()
         packet = self.framer.buildPacket(request)
-        _logger.debug("send: " + " ".join([hex(byte2int(x)) for x in packet]))
+        _logger.debug("send: " + hexlify_packets(packet))
         self.transport.write(packet)
         return self._buildResponse(request.transaction_id)
 


### PR DESCRIPTION
There is still some code where hex debug strings were composed using `hex(byte2int(x))` and list comprehensions. Exactly the same code has been made available via `pymodbus.utilities.hexlify_packets()`. Lets use this fuction everywhere to keep code nice and clean.