### PR TITLE
Don't install ez_setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,6 @@ setup(
     license='BSD-3-Clause',
     packages=find_packages(exclude=['examples', 'test']),
     exclude_package_data={'': ['examples', 'test', 'tools', 'doc']},
-    py_modules=['ez_setup'],
     platforms=['Linux', 'Mac OS X', 'Win'],
     include_package_data=True,
     zip_safe=True,


### PR DESCRIPTION
Listin it in py_modules causes it to be actually installed in the global site-packages dir. It doesn't seem to have to be mentioned in any way e.g. to still include it in the sdist tarball.