### PR TITLE
Implement asyncio ModbusSerialServer

### DIFF
--- a/examples/common/asyncio_server.py
+++ b/examples/common/asyncio_server.py
@@ -140,17 +140,16 @@ async def run_server():
     # #
     # await server.serve_forever()
 
-    # !!! SERIAL SERVER NOT IMPLEMENTED !!!
     # Ascii:
-    # StartSerialServer(context, identity=identity,
-    #                    port='/dev/ttyp0', timeout=1)
+    # await StartSerialServer(context, identity=identity,
+    #                    port='/dev/ttyp0', timeout=1, autoreconnect=True)
 
     # RTU:
-    # StartSerialServer(context, framer=ModbusRtuFramer, identity=identity,
-    #                   port='/dev/ttyp0', timeout=.005, baudrate=9600)
+    # await StartSerialServer(context, framer=ModbusRtuFramer, identity=identity,
+    #                    port='/dev/ttyp0', timeout=.005, baudrate=9600, autoreconnect=True)
 
     # Binary
-    # StartSerialServer(context,
+    # await StartSerialServer(context,
     #                   identity=identity,
     #                   framer=ModbusBinaryFramer,
     #                   port='/dev/ttyp0',

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -59,8 +59,7 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
         corresponds to the socket being opened
         """
         try:
-            sockname = transport.get_extra_info('sockname')
-            if sockname is not None:
+            if hasattr(transport, 'get_extra_info') and transport.get_extra_info('sockname') is not None:
                 _logger.debug("Socket [%s:%s] opened" % transport.get_extra_info('sockname'))
             else:
                 if hasattr(transport, 'serial'):
@@ -346,7 +345,6 @@ class ModbusSingleRequestHandler(ModbusBaseRequestHandler,asyncio.Protocol):
     """
     def connection_made(self, transport):
         super().connection_made(transport)
-
         _logger.debug("Serial connection established")
 
     def connection_lost(self, exc):


### PR DESCRIPTION
Main goal when implementing ModbusSerialServer was to have "bulletproof" server - `autoreconnect` option set to `True` will cause server to start/run even with specified port is not present. The use case is to be able to embed modbus server to some embedded device and forget about it, so that if server is running and user disconnects serial port physically and plugs it back, server will continue to operate. Same as server will be restarted when serial device is not present, then server will wait for it to become available and continue to serve.  
Setting `autoreconnect` to False will cause it to fail on start if serial device is not present.

I am creating this PR as draft so that you can review it and let me know if it right direction of development. 