### PR TITLE
Be able to create an AsyncModbusTCPClient from within a coroutine

### DIFF
--- a/pymodbus/client/asynchronous/factory/tcp.py
+++ b/pymodbus/client/asynchronous/factory/tcp.py
@@ -91,17 +91,19 @@ def async_io_factory(host="127.0.0.1", port=Defaults.Port, framer=None,
     """
     import asyncio
     from pymodbus.client.asynchronous.async_io import init_tcp_client
-    loop = kwargs.get("loop") or asyncio.new_event_loop()
+    loop = kwargs.get("loop") or asyncio.get_event_loop()
     proto_cls = kwargs.get("proto_cls", None)
     if not loop.is_running():
         asyncio.set_event_loop(loop)
         cor = init_tcp_client(proto_cls, loop, host, port)
         client = loop.run_until_complete(asyncio.gather(cor))[0]
     else:
-        cor = init_tcp_client(proto_cls, loop, host, port)
-        future = asyncio.run_coroutine_threadsafe(cor, loop=loop)
-        client = future.result()
-
+        if loop is asyncio.get_event_loop():
+            return init_tcp_client(proto_cls, loop, host, port)
+        else:
+            cor = init_tcp_client(proto_cls, loop, host, port)
+            future = asyncio.run_coroutine_threadsafe(cor, loop=loop)
+            client = future.result()
     return loop, client
 
 


### PR DESCRIPTION
This PR solves #557 by making it possible to create an AsyncModbusTCPClient from within a coroutine.

The change is that, if called from within the event loop, the AsyncModbusTCPClient returns a coroutine which, when awaited, should return a ModbusTCPClient object.

Here is how it would look like in practice:

```python
import asyncio

from pymodbus.client.asynchronous import schedulers
from pymodbus.client.asynchronous.tcp import AsyncModbusTCPClient

async def main():
    client = await AsyncModbusTCPClient(schedulers.ASYNC_IO, port=5020)
    print("Reading coils")
    rr = await client.read_coils(1, 1, unit=0x01)

asyncio.run(main())
```
Missing:
* [ ] Documentation
* [ ] Unit test