### PR TITLE
other: reportSlaveId: allow slaves to provide custom responses

### DIFF
--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -360,21 +360,26 @@ class ReportSlaveIdRequest(ModbusRequest):
         pass
 
     def execute(self, context=None):
-        ''' Run a read exeception status request against the store
+        ''' Run a report slave id request against the store
 
         :returns: The populated response
         '''
-        information = DeviceInformationFactory.get(_MCB)
-        identifier = "-".join(information.values()).encode()
-        identifier = identifier or b'Pymodbus'
-        return ReportSlaveIdResponse(identifier)
+        reportSlaveIdData = None
+        if context:
+            reportSlaveIdData = context.reportSlaveIdData
+        if not reportSlaveIdData:
+            information = DeviceInformationFactory.get(_MCB)
+            identifier = "-".join(information.values()).encode()
+            identifier = identifier or b'Pymodbus'
+            reportSlaveIdData = identifier
+        return ReportSlaveIdResponse(reportSlaveIdData)
 
     def __str__(self):
         ''' Builds a representation of the request
 
         :returns: The string representation of the request
         '''
-        return "ResportSlaveIdRequest(%d)" % self.function_code
+        return "ReportSlaveIdRequest(%d)" % self.function_code
 
 
 class ReportSlaveIdResponse(ModbusResponse):
@@ -430,7 +435,7 @@ class ReportSlaveIdResponse(ModbusResponse):
         :returns: The string representation of the response
         '''
         arguments = (self.function_code, self.identifier, self.status)
-        return "ResportSlaveIdResponse(%s, %s, %s)" % arguments
+        return "ReportSlaveIdResponse(%s, %s, %s)" % arguments
 
 #---------------------------------------------------------------------------#
 # TODO Make these only work on serial


### PR DESCRIPTION
At present, function code 17, "Report Slave ID" is hardcoded to reply
with a string joined form of the "device identification" fields from
function code 43, subcode 14 (0x2b, 0x0e)

There's nothing that actually implies these should be related.  This
change allows slave contexts to provide custom data to return via the
ModbusServerContext property reportSlaveIdData

If this is not provided, the existing fallback to the device
identification fields is used.

Signed-off-by: Karl Palsson <karlp@etactica.com>

I'm using this to make better fakes for existing devices, and those existing devices very much don't have the same data in both requests!

Open notes:
* Should this be done via extension of the "Datastore" instead?
* How should this be documented? changed to a function on IModbusSlaveContext instead?
* tests for this function don't have a context, should they?
