### PR TITLE
datastore: sparse stores shouldn't need an initial list

### DIFF
--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -192,11 +192,9 @@ class ModbusSequentialDataBlock(BaseModbusDataBlock):
 class ModbusSparseDataBlock(BaseModbusDataBlock):
     ''' Creates a sparse modbus datastore '''
 
-    def __init__(self, values):
-        ''' Initializes the datastore
-
-        Using the input values we create the default
-        datastore value and the starting address
+    def __init__(self, values=None):
+        ''' Initializes a sparse datastore. Will only answer to addresses
+        registered, either initially here, or later via setValues()
 
         :param values: Either a list or a dictionary of values
         '''
@@ -204,19 +202,14 @@ class ModbusSparseDataBlock(BaseModbusDataBlock):
             self.values = values
         elif hasattr(values, '__iter__'):
             self.values = dict(enumerate(values))
-        else: raise ParameterException(
-            "Values for datastore must be a list or dictionary")
-        self.default_value = get_next(itervalues(self.values)).__class__()
-        self.address = get_next(iterkeys(self.values))
+        else:
+            self.values = {}  # Must make a new dict here per instance
+        # We only need this to support .reset()
+        self.default_value = self.values.copy()
 
-    @classmethod
-    def create(klass):
-        ''' Factory method to create a datastore with the
-        full address space initialized to 0x00
-
-        :returns: An initialized datastore
-        '''
-        return klass([0x00] * 65536)
+    def reset(self):
+        ''' Reset the store to the intially provided defaults'''
+        self.values = self.default_value.copy()
 
     def validate(self, address, count=1):
         ''' Checks to see if the request is in range


### PR DESCRIPTION
Currently, to create a sparse data store, you are required to provide an
initial list/dict.  The first entry is then used as a "default" for the
reset() call, which seems rather at odds with the "sparse" nature.

Instead, use a supplied intial value if provided, and use that to
properly reset the store to _that_ value.  Similarly don't require an
initial list at all, allowing addresses/registers to be filled in via
follow up calls to .setValues()

Example old code: (We want to register 20 addresses at 0x2000}
```
 # must provide at least one initial value!
 hr = ModbusSparseDataBlock({0x2000: 0x55aa})
 # actually register what we want using flexible lists.
 hr.setValues(0x2000, [0]*20)
```

Example new code:
```
 hr = ModbusSparseDataBlock()
 hr.setValues(0x2000, [0]*20)
```
Example old code using reset:
```
 hr = ModbusSparseDataBlock({
	0x2000: 0x55,
	0x3000: 0x66
	})
 hr.reset()
```
At this point, the store contained two registers, 0x2000 and 0x2001,
both containing the value 0x55.  This hardly seems to have been the
intention of .reset() on a Sparse store, but is obvious for the
sequential store.

Fixes: https://github.com/riptideio/pymodbus/issues/566

Signed-off-by: Karl Palsson <karlp@etactica.com>
