### PR TITLE
other: fix report slave id improper fallback to default

### DIFF
--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -366,7 +366,7 @@ class ReportSlaveIdRequest(ModbusRequest):
         '''
         reportSlaveIdData = None
         if context:
-            reportSlaveIdData = context.reportSlaveIdData
+            reportSlaveIdData = getattr(context, 'reportSlaveIdData', None)
         if not reportSlaveIdData:
             information = DeviceInformationFactory.get(_MCB)
             identifier = "-".join(information.values()).encode()


### PR DESCRIPTION
Wrongly attempted to treat the object as a dict, needs to check if the
property is there at all.

Fixes: 042458b9fee: other: reportSlaveId: allow slaves to provide custom responses

Signed-off-by: Karl Palsson <karlp@tweak.net.au>

--
There's more work here, I don't believe the current object types work very well for this function code, but I'll come to gitter and discuss them before going further :)
