### PR TITLE
Disable strict mode for inter character timeout in Serial mode by default

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -552,7 +552,7 @@ class ModbusSerialClient(BaseModbusClient):
         self.parity = kwargs.get('parity',   Defaults.Parity)
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout = kwargs.get('timeout',  Defaults.Timeout)
-        self._strict = kwargs.get("strict", True)
+        self._strict = kwargs.get("strict", False)
         self.last_frame_end = None
         self.handle_local_echo = kwargs.get("handle_local_echo", False)
         if self.method == "rtu":


### PR DESCRIPTION
The _strict argument should be defaulted to False since the inter_char_timeout feature is not working correctly. Changes in the past have tried to fix the issue but one way or another they do not seem to work consistently across all computers and systems. Therefore I think by default the _strict argument should be set to False unless specified to prevent the faulty behavior from producing false timeouts.

There are two possible reasons why I think this feature may never work correclty:
* One the OS handling the timeout incorrectly if more than one character arrives at the same time if it is busy doing something else.
* Another one as described here https://stackoverflow.com/a/37053542/1813498 is the fact that the timeout value must be a multiple of 0.1. At 9600 the inter char value is calculated to be 0.00171875 and then rounded to 0 so therefore it will not work correctly.

The conclusion from my side is that it is not possible to accurately measure this timeout and should perhaps be removed. At least it should be by default disabled. This small patch aims to do the later.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
