### PR TITLE
Fixes for synchronized client and transaction handling

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -261,9 +261,9 @@ class ModbusTcpClient(BaseModbusClient):
 
         timeout = self.timeout
 
-        # If size isn't specified read 1 byte at a time.
+        # If size isn't specified read up to 4096 bytes at a time.
         if size is None:
-            recv_size = 1
+            recv_size = 4096
         else:
             recv_size = size
 

--- a/pymodbus/client/sync_diag.py
+++ b/pymodbus/client/sync_diag.py
@@ -1,0 +1,167 @@
+import socket
+import logging
+import time
+
+from pymodbus.constants import Defaults
+from pymodbus.client.sync import ModbusTcpClient
+from pymodbus.transaction import ModbusSocketFramer
+from pymodbus.exceptions import ConnectionException
+
+_logger = logging.getLogger(__name__)
+
+LOG_MSGS = {
+    'conn_msg': 'Connecting to modbus device %s',
+    'connfail_msg': 'Connection to (%s, %s) failed: %s',
+    'discon_msg': 'Disconnecting from modbus device %s',
+    'timelimit_read_msg':
+        'Modbus device read took %.4f seconds, '
+        'returned %s bytes in timelimit read',
+    'timeout_msg':
+        'Modbus device timeout after %.4f seconds, '
+        'returned %s bytes %s',
+    'delay_msg':
+        'Modbus device read took %.4f seconds, '
+        'returned %s bytes of %s expected',
+    'read_msg':
+        'Modbus device read took %.4f seconds, '
+        'returned %s bytes of %s expected',
+    'unexpected_dc_msg': '%s %s'}
+
+
+class ModbusTcpDiagClient(ModbusTcpClient):
+    """
+    Variant of pymodbus.client.sync.ModbusTcpClient with additional
+    logging to diagnose network issues.
+
+    The following events are logged:
+
+    +---------+-----------------------------------------------------------------+
+    | Level   | Events                                                          |
+    +=========+=================================================================+
+    | ERROR   | Failure to connect to modbus unit; unexpected disconnect by     |
+    |         | modbus unit                                                     |
+    +---------+-----------------------------------------------------------------+
+    | WARNING | Timeout on normal read; read took longer than warn_delay_limit  |
+    +---------+-----------------------------------------------------------------+
+    | INFO    | Connection attempt to modbus unit; disconnection from modbus    |
+    |         | unit; each time limited read                                    |
+    +---------+-----------------------------------------------------------------+
+    | DEBUG   | Normal read with timing information                             |
+    +---------+-----------------------------------------------------------------+
+
+    Reads are differentiated between "normal", which reads a specified number of
+    bytes, and "time limited", which reads all data for a duration equal to the
+    timeout period configured for this instance.
+    """
+
+    # pylint: disable=no-member
+
+    def __init__(self, host='127.0.0.1', port=Defaults.Port,
+                 framer=ModbusSocketFramer, **kwargs):
+        """ Initialize a client instance
+
+        The keys of LOG_MSGS can be used in kwargs to customize the messages.
+
+        :param host: The host to connect to (default 127.0.0.1)
+        :param port: The modbus port to connect to (default 502)
+        :param source_address: The source address tuple to bind to (default ('', 0))
+        :param timeout: The timeout to use for this socket (default Defaults.Timeout)
+        :param warn_delay_limit: Log reads that take longer than this as warning.
+               Default True sets it to half of "timeout". None never logs these as
+               warning, 0 logs everything as warning.
+        :param framer: The modbus framer to use (default ModbusSocketFramer)
+
+        .. note:: The host argument will accept ipv4 and ipv6 hosts
+        """
+        self.warn_delay_limit = kwargs.get('warn_delay_limit', True)
+        super().__init__(host, port, framer, **kwargs)
+        if self.warn_delay_limit is True:
+            self.warn_delay_limit = self.timeout / 2
+
+        # Set logging messages, defaulting to LOG_MSGS
+        for (k, v) in LOG_MSGS.items():
+            self.__dict__[k] = kwargs.get(k, v)
+
+    def connect(self):
+        """ Connect to the modbus tcp server
+
+        :returns: True if connection succeeded, False otherwise
+        """
+        if self.socket:
+            return True
+        try:
+            _logger.info(self.conn_msg, self)
+            self.socket = socket.create_connection(
+                (self.host, self.port),
+                timeout=self.timeout,
+                source_address=self.source_address)
+        except socket.error as msg:
+            _logger.error(self.connfail_msg, self.host, self.port, msg)
+            self.close()
+        return self.socket is not None
+
+    def close(self):
+        """ Closes the underlying socket connection
+        """
+        if self.socket:
+            _logger.info(self.discon_msg, self)
+            self.socket.close()
+        self.socket = None
+
+    def _recv(self, size):
+        try:
+            start = time.time()
+
+            result = super()._recv(size)
+
+            delay = time.time() - start
+            if self.warn_delay_limit is not None and delay >= self.warn_delay_limit:
+                self._log_delayed_response(len(result), size, delay)
+            elif not size:
+                _logger.debug(self.timelimit_read_msg, delay, len(result))
+            else:
+                _logger.debug(self.read_msg, delay, len(result), size)
+
+            return result
+        except ConnectionException as ex:
+            # Only log actual network errors, "if not self.socket" then it's a internal code issue
+            if 'Connection unexpectedly closed' in ex.string:
+                _logger.error(self.unexpected_dc_msg, self, ex)
+            raise ex
+
+    def _log_delayed_response(self, result_len, size, delay):
+        if not size and result_len > 0:
+            _logger.info(self.timelimit_read_msg, delay, result_len)
+        elif (result_len == 0 or (size and result_len < size)) and delay >= self.timeout:
+            read_type = ("of %i expected" % size) if size else "in timelimit read"
+            _logger.warning(self.timeout_msg, delay, result_len, read_type)
+        else:
+            _logger.warning(self.delay_msg, delay, result_len, size)
+
+    def __str__(self):
+        """ Builds a string representation of the connection
+
+        :returns: The string representation
+        """
+        return "ModbusTcpDiagClient(%s:%s)" % (self.host, self.port)
+
+
+def get_client():
+    """ Returns an appropriate client based on logging level
+
+    This will be ModbusTcpDiagClient by default, or the parent class
+    if the log level is such that the diagnostic client will not log
+    anything.
+
+    :returns: ModbusTcpClient or a child class thereof
+    """
+    return ModbusTcpDiagClient if _logger.isEnabledFor(logging.ERROR) else ModbusTcpClient
+
+
+# --------------------------------------------------------------------------- #
+# Exported symbols
+# --------------------------------------------------------------------------- #
+
+__all__ = [
+    "ModbusTcpDiagClient", "get_client"
+]

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -317,6 +317,10 @@ class ModbusTransactionManager(object):
             _logger.debug("{} received, "
                           "Expected {} bytes Recieved "
                           "{} bytes !!!!".format(msg_start, total, actual))
+        elif actual == 0:
+            # If actual == 0 and total is not None then the above
+            # should be triggered, so total must be None here
+            _logger.debug("No response received to unbounded read !!!!")
         if self.client.state != ModbusTransactionState.PROCESSING_REPLY:
             _logger.debug("Changing transaction state from "
                           "'WAITING FOR REPLY' to 'PROCESSING REPLY'")

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -200,6 +200,7 @@ class ModbusTransactionManager(object):
                                 "/Unable to decode response")
                             response = ModbusIOException(last_exception,
                                                          request.function_code)
+                        self.client.close()
                     if hasattr(self.client, "state"):
                         _logger.debug("Changing transaction state from "
                                       "'PROCESSING REPLY' to "
@@ -209,6 +210,7 @@ class ModbusTransactionManager(object):
                 return response
             except ModbusIOException as ex:
                 # Handle decode errors in processIncomingPacket method
+                self.client.close()
                 _logger.exception(ex)
                 self.client.state = ModbusTransactionState.TRANSACTION_COMPLETE
                 return ex

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -275,9 +275,10 @@ class ModbusTransactionManager(object):
 
             read_min = self.client.framer.recvPacket(min_size)
             if len(read_min) != min_size:
+                msg_start = "Incomplete message" if read_min else "No response"
                 raise InvalidMessageReceivedException(
-                    "Incomplete message received, expected at least %d bytes "
-                    "(%d received)" % (min_size, len(read_min))
+                    "%s received, expected at least %d bytes "
+                    "(%d received)" % (msg_start, min_size, len(read_min))
                 )
             if read_min:
                 if isinstance(self.client.framer, ModbusSocketFramer):
@@ -312,9 +313,10 @@ class ModbusTransactionManager(object):
         result = read_min + result
         actual = len(result)
         if total is not None and actual != total:
-            _logger.debug("Incomplete message received, "
+            msg_start = "Incomplete message" if actual else "No response"
+            _logger.debug("{} received, "
                           "Expected {} bytes Recieved "
-                          "{} bytes !!!!".format(total, actual))
+                          "{} bytes !!!!".format(msg_start, total, actual))
         if self.client.state != ModbusTransactionState.PROCESSING_REPLY:
             _logger.debug("Changing transaction state from "
                           "'WAITING FOR REPLY' to 'PROCESSING REPLY'")

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -265,6 +265,15 @@ class SynchronousClientTest(unittest.TestCase):
         mock_select.select.return_value = [True]
         self.assertIn(b'\x00', client._recv(None))
 
+        mock_socket = MagicMock()
+        mock_socket.recv.return_value = b''
+        client.socket = mock_socket
+        self.assertRaises(ConnectionException, lambda: client._recv(1024))
+
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02', b''])
+        client.socket = mock_socket
+        self.assertEqual(b'\x00\x01\x02', client._recv(1024))
+
     def testTcpClientRpr(self):
         client = ModbusTcpClient()
         rep = "<{} at {} socket={}, ipaddr={}, port={}, timeout={}>".format(

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 import unittest
+from itertools import count
+from io import StringIO
 from pymodbus.compat import IS_PYTHON3
 
 if IS_PYTHON3:  # Python 3
@@ -17,6 +19,8 @@ from pymodbus.exceptions import ConnectionException, NotImplementedException
 from pymodbus.exceptions import ParameterException
 from pymodbus.transaction import ModbusAsciiFramer, ModbusRtuFramer
 from pymodbus.transaction import ModbusBinaryFramer
+from pymodbus.transaction import ModbusSocketFramer
+from pymodbus.utilities import hexlify_packets
 
 
 # ---------------------------------------------------------------------------#
@@ -62,14 +66,28 @@ class SynchronousClientTest(unittest.TestCase):
         client = BaseModbusClient(None)
         client.transaction = None
         self.assertRaises(NotImplementedException, lambda: client.connect())
-        self.assertRaises(NotImplementedException, lambda: client._send(None))
-        self.assertRaises(NotImplementedException, lambda: client._recv(None))
+        self.assertRaises(NotImplementedException, lambda: client.send(None))
+        self.assertRaises(NotImplementedException, lambda: client.recv(None))
         self.assertRaises(NotImplementedException, lambda: client.__enter__())
         self.assertRaises(NotImplementedException, lambda: client.execute())
         self.assertRaises(NotImplementedException, lambda: client.is_socket_open())
         self.assertEqual("Null Transport", str(client))
         client.close()
         client.__exit__(0, 0, 0)
+
+        # Test information methods
+        client.last_frame_end = 2
+        client.silent_interval = 2
+        self.assertEqual(4, client.idle_time())
+        client.last_frame_end = None
+        self.assertEqual(0, client.idle_time())
+
+        # Test debug/trace/_dump methods
+        self.assertEqual(False, client.debug_enabled())
+        writable = StringIO()
+        client.trace(writable)
+        client._dump([0, 1, 2], None)
+        self.assertEqual(hexlify_packets([0, 1, 2]), writable.getvalue())
 
         # a successful execute
         client.connect = lambda: True
@@ -132,6 +150,11 @@ class SynchronousClientTest(unittest.TestCase):
             mock_method.side_effect = socket.error()
             client = ModbusUdpClient()
             self.assertFalse(client.connect())
+
+    def testUdpClientIsSocketOpen(self):
+        ''' Test the udp client is_socket_open method'''
+        client = ModbusUdpClient()
+        self.assertFalse(client.is_socket_open())
 
     def testUdpClientSend(self):
         ''' Test the udp client send method'''
@@ -201,6 +224,11 @@ class SynchronousClientTest(unittest.TestCase):
             client = ModbusTcpClient()
             self.assertFalse(client.connect())
 
+    def testTcpClientIsSocketOpen(self):
+        ''' Test the tcp client is_socket_open method'''
+        client = ModbusTcpClient()
+        self.assertFalse(client.is_socket_open())
+
     def testTcpClientSend(self):
         ''' Test the tcp client send method'''
         client = ModbusTcpClient()
@@ -210,11 +238,13 @@ class SynchronousClientTest(unittest.TestCase):
         self.assertEqual(0, client._send(None))
         self.assertEqual(4, client._send('1234'))
 
+    @patch('pymodbus.client.sync.time')
     @patch('pymodbus.client.sync.select')
-    def testTcpClientRecv(self, mock_select):
+    def testTcpClientRecv(self, mock_select, mock_time):
         ''' Test the tcp client receive method'''
 
         mock_select.select.return_value = [True]
+        mock_time.time.side_effect = count()
         client = ModbusTcpClient()
         self.assertRaises(ConnectionException, lambda: client._recv(1024))
 
@@ -225,7 +255,7 @@ class SynchronousClientTest(unittest.TestCase):
         mock_socket = MagicMock()
         mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
         client.socket = mock_socket
-        client.timeout = 1
+        client.timeout = 3
         self.assertEqual(b'\x00\x01\x02', client._recv(3))
         mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
         self.assertEqual(b'\x00\x01', client._recv(2))
@@ -235,7 +265,7 @@ class SynchronousClientTest(unittest.TestCase):
         mock_select.select.return_value = [True]
         self.assertIn(b'\x00', client._recv(None))
 
-    def testSerialClientRpr(self):
+    def testTcpClientRpr(self):
         client = ModbusTcpClient()
         rep = "<{} at {} socket={}, ipaddr={}, port={}, timeout={}>".format(
             client.__class__.__name__, hex(id(client)), client.socket,
@@ -307,19 +337,25 @@ class SynchronousClientTest(unittest.TestCase):
         self.assertEqual(0, client._send(None))
         self.assertEqual(4, client._send('1234'))
 
-    def testTlsClientRecv(self):
+    @patch('pymodbus.client.sync.time')
+    def testTlsClientRecv(self, mock_time):
         ''' Test the tls client receive method'''
         client = ModbusTlsClient()
         self.assertRaises(ConnectionException, lambda: client._recv(1024))
+
+        mock_time.time.side_effect = count()
 
         client.socket = mockSocket()
         self.assertEqual(b'', client._recv(0))
         self.assertEqual(b'\x00' * 4, client._recv(4))
 
+        client.timeout = 2
+        self.assertIn(b'\x00', client._recv(None))
+
         mock_socket = MagicMock()
         mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
         client.socket = mock_socket
-        client.timeout = 1
+        client.timeout = 3
         self.assertEqual(b'\x00\x01\x02', client._recv(3))
         mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
         self.assertEqual(b'\x00\x01', client._recv(2))
@@ -354,6 +390,8 @@ class SynchronousClientTest(unittest.TestCase):
                                    ModbusRtuFramer))
         self.assertTrue(isinstance(ModbusSerialClient(method='binary').framer,
                                    ModbusBinaryFramer))
+        self.assertTrue(isinstance(ModbusSerialClient(method='socket').framer,
+                                   ModbusSocketFramer))
         self.assertRaises(ParameterException,
                           lambda: ModbusSerialClient(method='something'))
 
@@ -384,6 +422,12 @@ class SynchronousClientTest(unittest.TestCase):
         self.assertTrue(client.connect())
         client.close()
 
+        # rtu connect/disconnect
+        rtu_client = ModbusSerialClient(method='rtu')
+        self.assertTrue(rtu_client.connect())
+        self.assertEqual(rtu_client.socket.interCharTimeout, rtu_client.inter_char_timeout)
+        rtu_client.close()
+
         # already closed socket
         client.socket = False
         client.close()
@@ -401,6 +445,14 @@ class SynchronousClientTest(unittest.TestCase):
             mock_method.side_effect = serial.SerialException()
             client = ModbusSerialClient()
             self.assertFalse(client.connect())
+
+    @patch("serial.Serial")
+    def testSerialClientIsSocketOpen(self, mock_serial):
+        ''' Test the serial client is_socket_open method'''
+        client = ModbusSerialClient()
+        self.assertFalse(client.is_socket_open())
+        client.socket = mock_serial
+        self.assertTrue(client.is_socket_open())
 
     @patch("serial.Serial")
     def testSerialClientSend(self, mock_serial):
@@ -444,6 +496,8 @@ class SynchronousClientTest(unittest.TestCase):
         self.assertEqual(b'', client._recv(None))
         client.socket.timeout = 0
         self.assertEqual(b'', client._recv(0))
+        client.timeout = None
+        self.assertEqual(b'', client._recv(None))
 
     def testSerialClientRepr(self):
         client = ModbusSerialClient()

--- a/test/test_client_sync_diag.py
+++ b/test/test_client_sync_diag.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python
+import unittest
+from itertools import count
+from pymodbus.compat import IS_PYTHON3
+
+if IS_PYTHON3:  # Python 3
+    from unittest.mock import patch, Mock, MagicMock
+else:  # Python 2
+    from mock import patch, Mock, MagicMock
+import socket
+
+from pymodbus.client.sync_diag import ModbusTcpDiagClient, get_client
+from pymodbus.exceptions import ConnectionException, NotImplementedException
+from pymodbus.exceptions import ParameterException
+from test.test_client_sync import mockSocket
+
+
+# ---------------------------------------------------------------------------#
+# Fixture
+# ---------------------------------------------------------------------------#
+class SynchronousDiagnosticClientTest(unittest.TestCase):
+    '''
+    This is the unittest for the pymodbus.client.sync_diag module. It is
+    a copy of parts of the test for the TCP class in the pymodbus.client.sync
+    module, as it should operate identically and only log some additional
+    lines.
+    '''
+
+    # -----------------------------------------------------------------------#
+    # Test TCP Diagnostic Client
+    # -----------------------------------------------------------------------#
+
+    def testSyncTcpDiagClientInstantiation(self):
+        client = get_client()
+        self.assertNotEqual(client, None)
+
+    def testBasicSyncTcpDiagClient(self):
+        ''' Test the basic methods for the tcp sync diag client'''
+
+        # connect/disconnect
+        client = ModbusTcpDiagClient()
+        client.socket = mockSocket()
+        self.assertTrue(client.connect())
+        client.close()
+
+    def testTcpDiagClientConnect(self):
+        ''' Test the tcp sync diag client connection method'''
+        with patch.object(socket, 'create_connection') as mock_method:
+            mock_method.return_value = object()
+            client = ModbusTcpDiagClient()
+            self.assertTrue(client.connect())
+
+        with patch.object(socket, 'create_connection') as mock_method:
+            mock_method.side_effect = socket.error()
+            client = ModbusTcpDiagClient()
+            self.assertFalse(client.connect())
+
+    @patch('pymodbus.client.sync.time')
+    @patch('pymodbus.client.sync_diag.time')
+    @patch('pymodbus.client.sync.select')
+    def testTcpDiagClientRecv(self, mock_select, mock_diag_time, mock_time):
+        ''' Test the tcp sync diag client receive method'''
+
+        mock_select.select.return_value = [True]
+        mock_time.time.side_effect = count()
+        mock_diag_time.time.side_effect = count()
+        client = ModbusTcpDiagClient()
+        self.assertRaises(ConnectionException, lambda: client._recv(1024))
+
+        client.socket = mockSocket()
+        # Test logging of non-delayed responses
+        self.assertIn(b'\x00', client._recv(None))
+        self.assertEqual(b'\x00', client._recv(1))
+
+        # Fool diagnostic logger into thinking we're running late,
+        # test logging of delayed responses
+        mock_diag_time.time.side_effect = count(step=3)
+        self.assertEqual(b'', client._recv(0))
+        self.assertEqual(b'\x00' * 4, client._recv(4))
+
+        mock_socket = MagicMock()
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
+        client.socket = mock_socket
+        client.timeout = 3
+        self.assertEqual(b'\x00\x01\x02', client._recv(3))
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02'])
+        self.assertEqual(b'\x00\x01', client._recv(2))
+        mock_select.select.return_value = [False]
+        self.assertEqual(b'', client._recv(2))
+        client.socket = mockSocket()
+        mock_select.select.return_value = [True]
+        self.assertIn(b'\x00', client._recv(None))
+
+        mock_socket = MagicMock()
+        mock_socket.recv.return_value = b''
+        client.socket = mock_socket
+        self.assertRaises(ConnectionException, lambda: client._recv(1024))
+
+        mock_socket.recv.side_effect = iter([b'\x00', b'\x01', b'\x02', b''])
+        client.socket = mock_socket
+        self.assertEqual(b'\x00\x01\x02', client._recv(1024))
+
+    def testTcpDiagClientRpr(self):
+        client = ModbusTcpDiagClient()
+        rep = "<{} at {} socket={}, ipaddr={}, port={}, timeout={}>".format(
+            client.__class__.__name__, hex(id(client)), client.socket,
+            client.host, client.port, client.timeout
+        )
+        self.assertEqual(repr(client), rep)
+
+
+# ---------------------------------------------------------------------------#
+# Main
+# ---------------------------------------------------------------------------#
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes in the synchronized client and the parts of the transaction manager used by the synchronized client.

This has all the work I did in the sync client for [gapit.io](https://github.com/gapitio). Let me know if this should be split up, for instance with just the #538 fix. The other commits are for issues I discovered while digging to find and fix that issue.

Sorry for not getting around to this before, things have popped up so that even if this sat almost ready and just needed a once or twice over it still got punted a month, but at least now it's presentable enough for a PR.

No sweat about merging all of this, gapit.io is using a fork for pymodbus, has been doing so for a long time and can do so for a while longer.