### PR TITLE
Update sync.py

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -552,7 +552,7 @@ class ModbusSerialClient(BaseModbusClient):
         self.parity = kwargs.get('parity',   Defaults.Parity)
         self.baudrate = kwargs.get('baudrate', Defaults.Baudrate)
         self.timeout = kwargs.get('timeout',  Defaults.Timeout)
-        self._strict = kwargs.get("strict", True)
+        self._strict = kwargs.get("strict", False)
         self.last_frame_end = None
         self.handle_local_echo = kwargs.get("handle_local_echo", False)
         if self.method == "rtu":


### PR DESCRIPTION
Set "strict" default to False since it mailfunctions

From: https://github.com/riptideio/pymodbus/pull/574 cherry picked to dev branch so it is there for the future.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
