### PR TITLE
BUGFIX?:  self._header needs to be set to {}

### DIFF
--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -60,7 +60,7 @@ class ModbusRtuFramer(ModbusFramer):
         :param decoder: The decoder factory implementation to use
         """
         self._buffer = b''
-        self._header = {'uid': 0x00, 'len': 0, 'crc': '0000'}
+        self._header = {}
         self._hsize = 0x01
         self._end = b'\x0d\x0a'
         self._min_frame_size = 4


### PR DESCRIPTION

self._header needs to be set to {}. If not, the first frame would always be missed.

populateHeader() is called in isFrameReady() and checkFrame(). In isFrameReady,
populateHeader is only called 'if not self._header', and checkFrame is only called
'if isFrameReady()'.

Reset also sets self._header to {}.

I did test with a async serial connection. Does fix my problem, was only checking for one answer.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
