### PR TITLE
"Reconnection retries" was added into Modbus TCP Client 

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -49,7 +49,7 @@ class BaseModbusClient(ModbusClientMixin):
     # ----------------------------------------------------------------------- #
     # Client interface
     # ----------------------------------------------------------------------- #
-    def connect(self):
+    def connect(self, retires=1):
         """ Connect to the modbus remote host
 
         :returns: True if connection succeeded, False otherwise
@@ -197,24 +197,32 @@ class ModbusTcpClient(BaseModbusClient):
         self.source_address = kwargs.get('source_address', ('', 0))
         self.socket = None
         self.timeout = kwargs.get('timeout',  Defaults.Timeout)
+        self.connection_status = False
         BaseModbusClient.__init__(self, framer(ClientDecoder(), self), **kwargs)
 
-    def connect(self):
-        """ Connect to the modbus tcp server
+    def connect(self, retries=1):
+        """ Connect to the modbus tcp server and retry if the previous connection
+        has been missed.
 
+        :param retries: The number of retires.
         :returns: True if connection succeeded, False otherwise
         """
-        if self.socket: return True
-        try:
-            self.socket = socket.create_connection(
-                (self.host, self.port),
-                timeout=self.timeout,
-                source_address=self.source_address)
-        except socket.error as msg:
-            _logger.error('Connection to (%s, %s) '
-                          'failed: %s' % (self.host, self.port, msg))
-            self.close()
-        return self.socket is not None
+        if self.socket:
+            return True
+        assert isinstance(retries, int) and retries > 0, "Input an unsigned integer as retries."
+        for _ in range(retries):
+            try:
+                self.socket = socket.create_connection(
+                    (self.host, self.port),
+                    timeout=self.timeout,
+                    source_address=self.source_address)
+            except socket.error as msg:
+                _logger.error('Connection to (%s, %s) '
+                              'failed: %s' % (self.host, self.port, msg))
+                self.close()
+            if self.socket is not None:
+                return True
+        return False
 
     def close(self):
         """ Closes the underlying socket connection
@@ -335,7 +343,7 @@ class ModbusTlsClient(ModbusTcpClient):
             self.sslctx.options |= ssl.OP_NO_SSLv2
         ModbusTcpClient.__init__(self, host, port, framer, **kwargs)
 
-    def connect(self):
+    def connect(self, retries=1):
         """ Connect to the modbus tls server
 
         :returns: True if connection succeeded, False otherwise
@@ -450,7 +458,7 @@ class ModbusUdpClient(BaseModbusClient):
             return socket.AF_INET
         return socket.AF_INET6
 
-    def connect(self):
+    def connect(self, retries=1):
         """ Connect to the modbus tcp server
 
         :returns: True if connection succeeded, False otherwise
@@ -582,7 +590,7 @@ class ModbusSerialClient(BaseModbusClient):
             return ModbusSocketFramer(ClientDecoder(), client)
         raise ParameterException("Invalid framer method requested")
 
-    def connect(self):
+    def connect(self, retries=1):
         """ Connect to the modbus serial server
 
         :returns: True if connection succeeded, False otherwise


### PR DESCRIPTION
I've added reconnect retries due to the handle of the connection failed at the first time into ModbusTcpClient.