### PR TITLE
Be able to create asyncio modbusclients from within a coroutine 

### DIFF
--- a/pymodbus/client/asynchronous/factory/serial.py
+++ b/pymodbus/client/asynchronous/factory/serial.py
@@ -90,8 +90,13 @@ def async_io_factory(port=None, framer=None, **kwargs):
     import asyncio
     from pymodbus.client.asynchronous.async_io import (ModbusClientProtocol,
                                                        AsyncioModbusSerialClient)
-    loop = kwargs.pop("loop", None) or asyncio.get_event_loop()
-    proto_cls = kwargs.pop("proto_cls", None) or ModbusClientProtocol
+
+    try:
+        loop = kwargs.pop("loop", None) or asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    proto_cls = kwargs.get("proto_cls") or ModbusClientProtocol
 
     try:
         from serial_asyncio import create_serial_connection
@@ -103,11 +108,12 @@ def async_io_factory(port=None, framer=None, **kwargs):
 
     client = AsyncioModbusSerialClient(port, proto_cls, framer, loop, **kwargs)
     coro = client.connect()
-    if loop.is_running():
+    if not loop.is_running():
+        loop.run_until_complete(coro)
+    elif loop is not asyncio.get_event_loop():
         future = asyncio.run_coroutine_threadsafe(coro, loop=loop)
         future.result()
-    else:
-        loop.run_until_complete(coro)
+
     return loop, client
 
 

--- a/pymodbus/client/asynchronous/factory/tcp.py
+++ b/pymodbus/client/asynchronous/factory/tcp.py
@@ -91,12 +91,20 @@ def async_io_factory(host="127.0.0.1", port=Defaults.Port, framer=None,
     """
     import asyncio
     from pymodbus.client.asynchronous.async_io import init_tcp_client
-    loop = kwargs.get("loop") or asyncio.new_event_loop()
-    proto_cls = kwargs.get("proto_cls", None)
+
+    try:
+        loop = kwargs.get("loop") or asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    proto_cls = kwargs.get("proto_cls")
+
     if not loop.is_running():
         asyncio.set_event_loop(loop)
         cor = init_tcp_client(proto_cls, loop, host, port)
         client = loop.run_until_complete(asyncio.gather(cor))[0]
+    elif loop is asyncio.get_event_loop():
+        client = init_tcp_client(proto_cls, loop, host, port)
     else:
         cor = init_tcp_client(proto_cls, loop, host, port)
         future = asyncio.run_coroutine_threadsafe(cor, loop=loop)

--- a/pymodbus/client/asynchronous/factory/tls.py
+++ b/pymodbus/client/asynchronous/factory/tls.py
@@ -29,13 +29,21 @@ def async_io_factory(host="127.0.0.1", port=Defaults.TLSPort, sslctx=None,
     """
     import asyncio
     from pymodbus.client.asynchronous.async_io import init_tls_client
-    loop = kwargs.get("loop") or asyncio.new_event_loop()
-    proto_cls = kwargs.get("proto_cls", None)
+
+    try:
+        loop = kwargs.get("loop") or asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    proto_cls = kwargs.get("proto_cls")
+
     if not loop.is_running():
         asyncio.set_event_loop(loop)
         cor = init_tls_client(proto_cls, loop, host, port, sslctx, server_hostname,
                               framer)
         client = loop.run_until_complete(asyncio.gather(cor))[0]
+    elif loop is asyncio.get_event_loop():
+        return loop, init_tls_client(proto_cls, loop, host, port)
     else:
         cor = init_tls_client(proto_cls, loop, host, port, sslctx, server_hostname,
                               framer)

--- a/pymodbus/client/asynchronous/factory/udp.py
+++ b/pymodbus/client/asynchronous/factory/udp.py
@@ -66,14 +66,24 @@ def async_io_factory(host="127.0.0.1", port=Defaults.Port, framer=None,
     """
     import asyncio
     from pymodbus.client.asynchronous.async_io import init_udp_client
-    loop = kwargs.get("loop") or asyncio.get_event_loop()
-    proto_cls = kwargs.get("proto_cls", None)
-    cor = init_udp_client(proto_cls, loop, host, port)
+
+    try:
+        loop = kwargs.get("loop") or asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+
+    proto_cls = kwargs.get("proto_cls")
+
     if not loop.is_running():
+        cor = init_udp_client(proto_cls, loop, host, port)
         client = loop.run_until_complete(asyncio.gather(cor))[0]
+    elif loop is asyncio.get_event_loop():
+        return loop, init_udp_client(proto_cls, loop, host, port)
     else:
+        cor = init_udp_client(proto_cls, loop, host, port)
         client = asyncio.run_coroutine_threadsafe(cor, loop=loop)
         client = client.result()
+
     return loop, client
 
 

--- a/test/test_client_async_asyncio.py
+++ b/test/test_client_async_asyncio.py
@@ -7,6 +7,11 @@ if IS_PYTHON3 and PYTHON_VERSION >= (3, 4):
         ReconnectingAsyncioModbusTcpClient,
         ModbusClientProtocol, ModbusUdpClientProtocol)
     from test.asyncio_test_helper import return_as_coroutine, run_coroutine
+    from pymodbus.client.asynchronous import schedulers
+    from pymodbus.client.asynchronous.serial import AsyncModbusSerialClient
+    from pymodbus.client.asynchronous.tcp import AsyncModbusTCPClient
+    from pymodbus.client.asynchronous.tls import AsyncModbusTLSClient
+    from pymodbus.client.asynchronous.udp import AsyncModbusUDPClient
     from pymodbus.factory import ClientDecoder
     from pymodbus.exceptions import ConnectionException
     from pymodbus.transaction import ModbusSocketFramer
@@ -67,6 +72,40 @@ class TestAsyncioClient(object):
 
         assert client.loop is mock_loop
         assert client.protocol_class is mock_protocol_class
+
+    @pytest.mark.asyncio
+    async def test_initialization_tcp_in_loop(self):
+        _, client = AsyncModbusTCPClient(schedulers.ASYNC_IO, port=5020)
+        client = await client
+
+        assert not client.connected
+        assert client.port == 5020
+        assert client.delay_ms < client.DELAY_MAX_MS
+
+    @pytest.mark.asyncio
+    async def test_initialization_udp_in_loop(self):
+        _, client = AsyncModbusUDPClient(schedulers.ASYNC_IO, port=5020)
+        client = await client
+
+        assert client.connected
+        assert client.port == 5020
+        assert client.delay_ms < client.DELAY_MAX_MS
+
+    @pytest.mark.asyncio
+    async def test_initialization_tls_in_loop(self):
+        _, client = AsyncModbusTLSClient(schedulers.ASYNC_IO, port=5020)
+        client = await client
+
+        assert not client.connected
+        assert client.port == 5020
+        assert client.delay_ms < client.DELAY_MAX_MS
+
+    @pytest.mark.asyncio
+    async def test_initialization_serial_in_loop(self):
+        _, client = AsyncModbusSerialClient(schedulers.ASYNC_IO, port='/tmp/ptyp0', baudrate=9600, method='rtu')
+
+        assert client.port == '/tmp/ptyp0'
+        assert client.baudrate == 9600
 
     def test_factory_reset_wait_before_reconnect(self):
         mock_protocol_class = mock.MagicMock()


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Based on PR #558 from @tiagocoutinho since that work seems to be stalled.

@memetb : I think calling `get_event_loop()` is the right call here, since the code still needs to work when no loop is present. The alternative of calling `get_event_loop()` would be something like:
```python
try:
    loop = kwargs.get("loop") or asyncio.get_running_loop()
except RuntimeError:
    loop = asyncio.new_event_loop()
```

But that is exactly what  `get_event_loop()` [does](https://github.com/python/cpython/blob/e3ef4d7f653976ac0ccacc4e3fde06bf0e0f139b/Lib/asyncio/events.py#L752).

There were some small style differences between `tcp`, `udp`, `tls` and `serial`, I made the the code more similar to make it easier to compare. I noticed that for `tcp` and `tls` `asyncio.set_event_loop(loop)` is called, but not for `udp` and `serial`, is that intended? I don't know enough of asyncio to say.

I don't think this way of also returning the loop and the client when running in a coroutine is particularly elegant since you can't await part of a returned tuple so you'll need to do something like this:
```python
loop, client = AsyncModbusUDPClient(schedulers.ASYNC_IO, port=5020)
awaited_client = await client
```

I added some tests, but I expect they can be improved.

I also noticed that only the `tls` code would fail when calling `get_event_loop()` without catching `RuntimeError`, so the other code doesn't seem to be tested without a loop argument or a running loop.