### PR TITLE
Properly process incomplete RTU frames, improve test coverage

### DIFF
--- a/test/test_transaction.py
+++ b/test/test_transaction.py
@@ -455,7 +455,7 @@ class ModbusTransactionTest(unittest.TestCase):
 
         msg_parts = [b"\x00\x01\x00", b"\x00\x00\x01\xfc\x1b"]
         self._rtu.addToFrame(msg_parts[0])
-        self.assertTrue(self._rtu.isFrameReady())
+        self.assertFalse(self._rtu.isFrameReady())
         self.assertFalse(self._rtu.checkFrame())
 
         self._rtu.addToFrame(msg_parts[1])


### PR DESCRIPTION
This change fixes errors in processing of incomplete frames. Some of them lead to the situation where the framer starts raising exception for all future frames. For example, when only first byte is added to self._buffer, self.populateHeader() adds unit ID to self._header only, and self.isFrameReady() starts raising exceptions until framer instance is re-created.

On the other hand, the code of RTU framer now is consistent with implementation of other framer (same function do the same).

Additionally, to be sure that all changes work, more test module was populated with some new tests, which also improves coverage.