### PR TITLE
#629 Add kwarg 'reset_socket' to disable closing sockets on error

### DIFF
--- a/pymodbus/repl/client/main.py
+++ b/pymodbus/repl/client/main.py
@@ -233,9 +233,10 @@ def cli(client):
 @click.option("--retry-on-error", is_flag=True, default=False,
               help="Retry on error response")
 @click.option("--retries", default=3, help="Retry count")
+@click.option("--reset-socket/--no-reset-socket", default=True, help="Reset client socket on error")
 @click.pass_context
 def main(ctx, verbose, broadcast_support, retry_on_empty,
-         retry_on_error, retries):
+         retry_on_error, retries, reset_socket):
     if verbose:
         global log
         import logging
@@ -248,7 +249,8 @@ def main(ctx, verbose, broadcast_support, retry_on_empty,
         "broadcast": broadcast_support,
         "retry_on_empty": retry_on_empty,
         "retry_on_invalid": retry_on_error,
-        "retries": retries
+        "retries": retries,
+        "reset_socket": reset_socket
     }
 
 

--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -25,7 +25,8 @@ __________                          .______.                    _________
  |     ___<   |  |/     \ /  _ \ / __ |  | __ \|  |  \/  ___/  \_____  \_/ __ \_  __ \  \/ // __ \_  __ \\
  |    |    \___  |  Y Y  (  <_> ) /_/ |  | \_\ \  |  /\___ \   /        \  ___/|  | \/\   /\  ___/|  | \/
  |____|    / ____|__|_|  /\____/\____ |  |___  /____//____  > /_______  /\___  >__|    \_/  \___  >__|
-           \/          \/            \/      \/           \/          \/     \/                 \/"""
+           \/          \/            \/      \/           \/          \/     \/                 \/
+"""
 
 SMALL_TITLE = "Pymodbus server..."
 BOTTOM_TOOLBAR = HTML('(MODBUS SERVER) <b><style bg="ansired">Press Ctrl+C or '
@@ -80,7 +81,9 @@ CUSTOM_FORMATTERS = [
 
 
 def info(message):
-    click.secho(str(message), fg="green")
+    if not isinstance(message, str):
+        message = str(message)
+    click.secho(message, fg="green")
 
 
 def warning(message):
@@ -191,12 +194,12 @@ async def interactive_shell(server):
 
 
 async def main(server):
-    with patch_stdout():
-        try:
-            await interactive_shell(server)
-        finally:
-            pass
-        warning("Bye Bye!!!")
+    # with patch_stdout():
+    try:
+        await interactive_shell(server)
+    finally:
+        pass
+    warning("Bye Bye!!!")
 
 
 async def run_repl(server):


### PR DESCRIPTION
Closes #629 

Starting pymodbus 2.5.0 on error client is closed and a new socket is initialized on a new request. This seems to be having adverse effect on the functionality of pymodbus with some of the hardwares. As a workaround, introducing new kwarg `reset_socket` which is set to `True` by default implying socket will be closed on error. Setting this to `False` will keep the socket open till client is explicitly closed or application is stopped.

Example usage
```
client = ModbusSerialClient(method='rtu',....., reset_socket=False)
```
