### PR TITLE
select proper bitness from pypy externals for windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           mkdir --parents $(dirname $PYPY_EXTERNALS_PATH)
           hg clone https://foss.heptapod.net/pypy/externals/ $PYPY_EXTERNALS_PATH
           dir $PYPY_EXTERNALS_PATH
-          cd $PYPY_EXTERNALS_PATH && hg update win$(pypy -c 'import struct; print(struct.calcsize("P") * 8)')_14x
+          cd $PYPY_EXTERNALS_PATH && hg update win$(python -c 'import struct; print(struct.calcsize("P") * 8)')_14x
           echo "INCLUDE=$PYPY_EXTERNALS_PATH/include;$INCLUDE" >> $GITHUB_ENV
           echo "LIB=$PYPY_EXTERNALS_PATH/lib;$LIB" >> $GITHUB_ENV
 #          echo "CL=${{ matrix.PYTHON.CL_FLAGS }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           mkdir --parents $(dirname $PYPY_EXTERNALS_PATH)
           hg clone https://foss.heptapod.net/pypy/externals/ $PYPY_EXTERNALS_PATH
           dir $PYPY_EXTERNALS_PATH
-          cd $PYPY_EXTERNALS_PATH && hg update win64_14x
+          cd $PYPY_EXTERNALS_PATH && hg update win$(pypy -c 'import struct; print(struct.calcsize("P") * 8)')_14x
           echo "INCLUDE=$PYPY_EXTERNALS_PATH/include;$INCLUDE" >> $GITHUB_ENV
           echo "LIB=$PYPY_EXTERNALS_PATH/lib;$LIB" >> $GITHUB_ENV
 #          echo "CL=${{ matrix.PYTHON.CL_FLAGS }}" >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
           mkdir --parents $(dirname $PYPY_EXTERNALS_PATH)
           hg clone https://foss.heptapod.net/pypy/externals/ $PYPY_EXTERNALS_PATH
           dir $PYPY_EXTERNALS_PATH
-          cd $PYPY_EXTERNALS_PATH && hg update win32_14x
+          cd $PYPY_EXTERNALS_PATH && hg update win64_14x
           echo "INCLUDE=$PYPY_EXTERNALS_PATH/include;$INCLUDE" >> $GITHUB_ENV
           echo "LIB=$PYPY_EXTERNALS_PATH/lib;$LIB" >> $GITHUB_ENV
 #          echo "CL=${{ matrix.PYTHON.CL_FLAGS }}" >> $GITHUB_ENV


### PR DESCRIPTION
PyPy went to 64 bit between 7.3.3 and 7.3.4 which happened between the last good build riptideio/pymodbus@de0cc3e and the first bad one at riptideio/pymodbus@a22932e.  We need to update to use the 64-bit PyPy externals reference to get the needed libraries for building cryptography.  Also, 7.3.4 dropped Python 3.6 support so our 3.6 tests will continue with 32-bit PyPy 7.3.3.