### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ For those of you that just want to get started fast, here you go::
     client.close()
 
 For more advanced examples, check out the `Examples <https://pymodbus.readthedocs.io/en/dev/source/example/modules.html>`_ included in the
-respository. If you have created any utilities that meet a specific
+repository. If you have created any utilities that meet a specific
 need, feel free to submit them so others can benefit.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -113,7 +113,7 @@ get lost in the noise: http://groups.google.com/group/pymodbus or
 at gitter:  https://gitter.im/pymodbus_dev/Lobby
 
 .. important::
-   **Note For async clients, it is recomended to use `asyncio` as the async facilitator (Python 3.6 and above).**
+   **Note For async clients, it is recommended to use `asyncio` as the async facilitator (Python 3.6 and above).**
    **If using tornado make sure the tornado version is `4.5.3`.Other versions of tornado can break the implementation**
 
 

--- a/examples/common/async_asyncio_client.py
+++ b/examples/common/async_asyncio_client.py
@@ -4,7 +4,7 @@ Pymodbus Asynchronous Client Examples
 --------------------------------------------------------------------------
 
 The following is an example of how to use the asynchronous modbus
-client implementation from pymodbus with ayncio.
+client implementation from pymodbus with asyncio.
 
 The example is only valid on Python3.4 and above
 """

--- a/examples/common/async_asyncio_serial_client.py
+++ b/examples/common/async_asyncio_serial_client.py
@@ -4,7 +4,7 @@ Pymodbus Asynchronous Client Examples
 --------------------------------------------------------------------------
 
 The following is an example of how to use the asynchronous serial modbus
-client implementation from pymodbus with ayncio.
+client implementation from pymodbus with asyncio.
 
 The example is only valid on Python3.4 and above
 """

--- a/examples/common/asynchronous_processor.py
+++ b/examples/common/asynchronous_processor.py
@@ -7,7 +7,7 @@ The following is a full example of a continuous client processor. Feel
 free to use it as a skeleton guide in implementing your own.
 """
 # --------------------------------------------------------------------------- #
-# import the neccessary modules
+# import the necessary modules
 # --------------------------------------------------------------------------- #
 from twisted.internet import serialport, reactor
 from twisted.internet.protocol import ClientFactory
@@ -46,7 +46,7 @@ UNIT = 0x01
 # --------------------------------------------------------------------------- #
 # an example custom protocol
 # --------------------------------------------------------------------------- #
-# Here you can perform your main procesing loop utilizing defereds and timed
+# Here you can perform your main processing loop utilizing defereds and timed
 # callbacks.
 # --------------------------------------------------------------------------- #
 class ExampleProtocol(ModbusClientProtocol):

--- a/examples/contrib/asynchronous_asyncio_modbus_tls_client.py
+++ b/examples/contrib/asynchronous_asyncio_modbus_tls_client.py
@@ -8,7 +8,7 @@ that uses Python builtin module ssl - TLS/SSL wrapper for socket objects for
 the TLS feature and asyncio.
 """
 # -------------------------------------------------------------------------- #
-# import neccessary libraries
+# import necessary libraries
 # -------------------------------------------------------------------------- #
 import ssl
 from pymodbus.client.asynchronous.tls import AsyncModbusTLSClient

--- a/examples/contrib/bcd_payload.py
+++ b/examples/contrib/bcd_payload.py
@@ -142,7 +142,7 @@ class BcdPayloadBuilder(IPayloadBuilder):
 class BcdPayloadDecoder(object):
     """
     A utility that helps decode binary coded decimal payload
-    messages from a modbus reponse message. What follows is
+    messages from a modbus response message. What follows is
     a simple example::
 
         decoder = BcdPayloadDecoder(payload)

--- a/examples/contrib/concurrent_client.py
+++ b/examples/contrib/concurrent_client.py
@@ -26,7 +26,7 @@ except ImportError:
     from futures import Future
 
 # -------------------------------------------------------------------------- #
-# import neccessary modbus libraries
+# import necessary modbus libraries
 # -------------------------------------------------------------------------- #
 from pymodbus.client.common import ModbusClientMixin
 

--- a/examples/contrib/message_parser.py
+++ b/examples/contrib/message_parser.py
@@ -53,7 +53,7 @@ class Decoder(object):
     def decode(self, message):
         """ Attempt to decode the supplied message
 
-        :param message: The messge to decode
+        :param message: The message to decode
         """
         if IS_PYTHON3:
             value = message if self.encode else c.encode(message, 'hex_codec')

--- a/examples/contrib/modbus_saver.py
+++ b/examples/contrib/modbus_saver.py
@@ -33,7 +33,7 @@ import xml.etree.ElementTree as xml
 class ModbusDatastoreSaver(object):
     """ An abstract base class that can be used to implement
     a persistance format for the modbus server context. In
-    order to use it, just complete the neccessary callbacks
+    order to use it, just complete the necessary callbacks
     (SAX style) that your persistance format needs.
     """
 

--- a/examples/contrib/modbus_simulator.py
+++ b/examples/contrib/modbus_simulator.py
@@ -85,7 +85,7 @@ class Configuration:
         """ Parses the config file and creates a server context
         """
         handle = pickle.load(self.file)
-        try:  # test for existance, or bomb
+        try:  # test for existence, or bomb
             dsd = handle['di']
             csd = handle['ci']
             hsd = handle['hr']

--- a/examples/contrib/modbus_tls_client.py
+++ b/examples/contrib/modbus_tls_client.py
@@ -8,7 +8,7 @@ Python builtin module ssl - TLS/SSL wrapper for socket objects for the TLS
 feature.
 """
 # -------------------------------------------------------------------------- #
-# import neccessary libraries
+# import necessary libraries
 # -------------------------------------------------------------------------- #
 import ssl
 from pymodbus.client.sync import ModbusTlsClient

--- a/examples/contrib/modicon_payload.py
+++ b/examples/contrib/modicon_payload.py
@@ -147,7 +147,7 @@ class ModiconPayloadBuilder(IPayloadBuilder):
 class ModiconPayloadDecoder(object):
     """
     A utility that helps decode modicon encoded payload
-    messages from a modbus reponse message. What follows is
+    messages from a modbus response message. What follows is
     a simple example::
 
         decoder = ModiconPayloadDecoder(payload)

--- a/examples/contrib/remote_server_context.py
+++ b/examples/contrib/remote_server_context.py
@@ -174,7 +174,7 @@ class RemoteServerContext(object):
     def __contains__(self, slave):
         """ Check if the given slave is in this list
 
-        :param slave: slave The slave to check for existance
+        :param slave: slave The slave to check for existence
         :returns: True if the slave exists, False otherwise
         """
         # we don't want to check the cache here as the

--- a/examples/gui/bottle/frontend.py
+++ b/examples/gui/bottle/frontend.py
@@ -223,7 +223,7 @@ def build_application(server):
     """ Helper method to create and initiailze a bottle application
 
     :param server: The modbus server to pull instance data from
-    :returns: An initialied bottle application
+    :returns: An initialized bottle application
     """
     log.info("building web application")
     api = ModbusApiWebApp(server)

--- a/examples/gui/bottle/media/js/backbone.js
+++ b/examples/gui/bottle/media/js/backbone.js
@@ -1161,7 +1161,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },

--- a/examples/tools/build_datastore.py
+++ b/examples/tools/build_datastore.py
@@ -33,7 +33,7 @@ class ConfigurationException(Exception):
 # Datablock Builders
 #--------------------------------------------------------------------------#
 def build_translation(option, opt, value, parser):
-    """ Converts a register dump list to a pickeld datastore
+    """ Converts a register dump list to a pickled datastore
 
     :param option: The option instance
     :param opt: The option string specified

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -307,7 +307,7 @@ class ModbusTcpClient(BaseModbusClient):
 
             # Timeout is reduced also if some data has been received in order
             # to avoid infinite loops when there isn't an expected response
-            # size and the slave sends noisy data continuosly.
+            # size and the slave sends noisy data continuously.
             if time_ > end:
                 break
 
@@ -448,7 +448,7 @@ class ModbusTlsClient(ModbusTcpClient):
 
             # Timeout is reduced also if some data has been received in order
             # to avoid infinite loops when there isn't an expected response
-            # size and the slave sends noisy data continuosly.
+            # size and the slave sends noisy data continuously.
             if time_ > end:
                 break
 

--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -224,7 +224,7 @@ class DeviceInformation(Singleton):
     .. attribute:: Regular
 
        In addition to basic data objects, the device provides additional
-       and optinoal identification and description data objects. All of
+       and optional identification and description data objects. All of
        the objects of this category are defined in the standard but their
        implementation is optional.
 

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -132,7 +132,7 @@ class ModbusServerContext(object):
     def __contains__(self, slave):
         ''' Check if the given slave is in this list
 
-        :param slave: slave The slave to check for existance
+        :param slave: slave The slave to check for existence
         :returns: True if the slave exists, False otherwise
         '''
         if self.single and self._slaves:

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -241,7 +241,7 @@ class ModbusSparseDataBlock(BaseModbusDataBlock):
         return klass(values)
 
     def reset(self):
-        ''' Reset the store to the intially provided defaults'''
+        ''' Reset the store to the initially provided defaults'''
         self.values = self.default_value.copy()
 
     def validate(self, address, count=1):

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -467,7 +467,7 @@ class ModbusCountersHandler(object):
 #---------------------------------------------------------------------------#
 class ModbusControlBlock(Singleton):
     '''
-    This is a global singleotn that controls all system information
+    This is a global singleton that controls all system information
 
     All activity should be logged here and all diagnostic requests
     should come from here.

--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -273,7 +273,7 @@ class BinaryPayloadBuilder(IPayloadBuilder):
 class BinaryPayloadDecoder(object):
     """
     A utility that helps decode payload messages from a modbus
-    reponse message.  It really is just a simple wrapper around
+    response message.  It really is just a simple wrapper around
     the struct module, however it saves time looking up the format
     strings. What follows is a simple example::
 

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -155,7 +155,7 @@ class ExtendedRequestSupport(object):
         Write `value` to coil at `address`.
 
         :param address: coil offset to write to
-        :param values: list of bit values to write (comma seperated)
+        :param values: list of bit values to write (comma separated)
         :param unit: The slave unit this request is targeting
         :return:
         """
@@ -183,7 +183,7 @@ class ExtendedRequestSupport(object):
         Write list of `values` to registers starting at `address`.
 
         :param address: register offset to write to
-        :param values: list of register value to write (comma seperated)
+        :param values: list of register value to write (comma separated)
         :param unit: The slave unit this request is targeting
         :return:
         """
@@ -239,7 +239,7 @@ class ExtendedRequestSupport(object):
         :param read_address: register offset to read from
         :param read_count: Number of registers to read
         :param write_address: register offset to write to
-        :param write_registers: List of register values to write (comma seperated)
+        :param write_registers: List of register values to write (comma separated)
         :param unit: The slave unit this request is targeting
         :return:
         """

--- a/pymodbus/utilities.py
+++ b/pymodbus/utilities.py
@@ -239,7 +239,7 @@ def rtuFrameSize(data, byte_count_pos):
 
 def hexlify_packets(packet):
     """
-    Returns hex representation of bytestring recieved
+    Returns hex representation of bytestring received
     :param packet:
     :return:
     """

--- a/test/test_server_sync.py
+++ b/test/test_server_sync.py
@@ -278,7 +278,7 @@ class SynchronousServerTest(unittest.TestCase):
     # Test TLS Server
     #-----------------------------------------------------------------------#
     def testTlsServerInit(self):
-        ''' test that the synchronous TLS server intial correctly '''
+        ''' test that the synchronous TLS server initial correctly '''
         with patch.object(socketserver.TCPServer, 'server_activate'):
             with patch.object(ssl.SSLContext, 'load_cert_chain') as mock_method:
                 identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})


### PR DESCRIPTION
There are small typos in:
- README.rst
- examples/common/async_asyncio_client.py
- examples/common/async_asyncio_serial_client.py
- examples/common/asynchronous_processor.py
- examples/contrib/asynchronous_asyncio_modbus_tls_client.py
- examples/contrib/bcd_payload.py
- examples/contrib/concurrent_client.py
- examples/contrib/message_parser.py
- examples/contrib/modbus_saver.py
- examples/contrib/modbus_simulator.py
- examples/contrib/modbus_tls_client.py
- examples/contrib/modicon_payload.py
- examples/contrib/remote_server_context.py
- examples/gui/bottle/frontend.py
- examples/gui/bottle/media/js/backbone.js
- examples/tools/build_datastore.py
- pymodbus/client/sync.py
- pymodbus/constants.py
- pymodbus/datastore/context.py
- pymodbus/datastore/store.py
- pymodbus/device.py
- pymodbus/payload.py
- pymodbus/repl/client/mclient.py
- pymodbus/utilities.py
- test/test_server_sync.py

Fixes:
- Should read `necessary` rather than `neccessary`.
- Should read `separated` rather than `seperated`.
- Should read `response` rather than `reponse`.
- Should read `existence` rather than `existance`.
- Should read `continuously` rather than `continuosly`.
- Should read `asyncio` rather than `ayncio`.
- Should read `singleton` rather than `singleotn`.
- Should read `repository` rather than `respository`.
- Should read `recommended` rather than `recomended`.
- Should read `received` rather than `recieved`.
- Should read `processing` rather than `procesing`.
- Should read `preferred` rather than `prefered`.
- Should read `pickled` rather than `pickeld`.
- Should read `optional` rather than `optinoal`.
- Should read `message` rather than `messge`.
- Should read `initially` rather than `intially`.
- Should read `initialized` rather than `initialied`.
- Should read `initial` rather than `intial`.

Closes #642

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
