### PR TITLE
sync/ModbusTlsServer: Fix ModbusTlsServer's default framer

### DIFF
--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -400,6 +400,7 @@ class ModbusTlsServer(ModbusTcpServer):
         :param broadcast_enable: True to treat unit_id 0 as broadcast address,
                         False to treat 0 as any other unit_id
         """
+        framer = framer or ModbusTlsFramer
         self.sslctx = sslctx
         if self.sslctx is None:
             self.sslctx = ssl.create_default_context()

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -22,7 +22,7 @@ from pymodbus.exceptions import ConnectionException, NotImplementedException
 from pymodbus.exceptions import ParameterException
 from pymodbus.transaction import ModbusAsciiFramer, ModbusRtuFramer
 from pymodbus.transaction import ModbusBinaryFramer
-from pymodbus.transaction import ModbusSocketFramer
+from pymodbus.transaction import ModbusSocketFramer, ModbusTlsFramer
 from pymodbus.utilities import hexlify_packets
 
 
@@ -315,6 +315,7 @@ class SynchronousClientTest(unittest.TestCase):
         # default SSLContext
         client = ModbusTlsClient()
         self.assertNotEqual(client, None)
+        self.assertIsInstance(client.framer, ModbusTlsFramer)
         self.assertTrue(client.sslctx)
 
         # user defined SSLContext

--- a/test/test_server_sync.py
+++ b/test/test_server_sync.py
@@ -19,6 +19,7 @@ from pymodbus.server.sync import StartTcpServer, StartTlsServer, StartUdpServer,
 from pymodbus.exceptions import NotImplementedException
 from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
 from pymodbus.datastore import ModbusServerContext
+from pymodbus.transaction import ModbusTlsFramer
 
 from pymodbus.compat import socketserver
 
@@ -284,6 +285,7 @@ class SynchronousServerTest(unittest.TestCase):
                 identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
                 server = ModbusTlsServer(context=None, identity=identity,
                                          bind_and_activate=False)
+                self.assertIs(server.framer, ModbusTlsFramer)
                 server.server_activate()
                 self.assertIsNotNone(server.sslctx)
                 self.assertEqual(type(server.socket), ssl.SSLSocket)


### PR DESCRIPTION
ModbusTlsServer's framer is set as ModbusTlsFramer by caller
StartTlsServer. However, if developers invoke ModbusTlsServer directly
without assigned framer, the framer will be assigned as
ModbusSocketFramer. Because, ModbusTlsServer inherits from
ModbusTcpServer. This parses payload failed for ModbusTlsServer.
This patch assigns ModbusTlsServer's default framer as ModbusTlsFramer.
And, adds corresponding unittest. (Add sync/ModbusTlsClient's framer
test as well)

Fixes #644