### PR TITLE
Treat exception codes as valid responses

### DIFF
--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -123,7 +123,7 @@ class ModbusTransactionManager(object):
             return False
 
         mbap = self.client.framer.decode_data(response)
-        if mbap.get('unit') != request.unit_id or mbap.get('fcode') != request.function_code:
+        if mbap.get('unit') != request.unit_id or mbap.get('fcode') & 0x7F != request.function_code:
             return False
 
         if 'length' in mbap and exp_resp_len:


### PR DESCRIPTION
When an exception response is received the function code is different from the request but the frame should still be considered valid.