### PR TITLE
Add missing identity argument to ModbusSerialServer

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -712,12 +712,13 @@ class ModbusSerialServer(object):
 
     handler = None
 
-    def __init__(self, context, framer=None, **kwargs):  # pragma: no cover
+    def __init__(self, context, framer=None, identity=None, **kwargs):  # pragma: no cover
         """ Overloaded initializer for the socket server
-        If the identify structure is not passed in, the ModbusControlBlock
+        If the identity structure is not passed in, the ModbusControlBlock
         uses its own empty structure.
         :param context: The ModbusServerContext datastore
         :param framer: The framer strategy to use
+        :param identity: An optional identify structure
         :param port: The serial port to attach to
         :param stopbits: The number of stop bits to use
         :param bytesize: The bytesize of the serial messages
@@ -753,6 +754,10 @@ class ModbusSerialServer(object):
         self.decoder = ServerDecoder()
         self.context = context or ModbusServerContext()
         self.response_manipulator = kwargs.get("response_manipulator", None)
+        self.control = ModbusControlBlock()
+        if isinstance(identity, ModbusDeviceIdentification):
+            self.control.Identity.update(identity)
+
         self.protocol = None
         self.transport = None
 


### PR DESCRIPTION
It is passed in by StartSerialServer but no argument
of the constructor accepts it, resulting in a runtime
failure:

  File ".../site-packages/pymodbus/server/async_io.py",
line 932, in StartSerialServer
    server = ModbusSerialServer(context, framer, identity, **kwargs)
TypeError: __init__() takes from 2 to 3 positional arguments but 4 were
given