### PR TITLE
Lint and cleanup /examples

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,5 @@
+[BASIC]
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=rr,rq
+

--- a/examples/common/async_asyncio_client.py
+++ b/examples/common/async_asyncio_client.py
@@ -68,27 +68,27 @@ async def start_async_test(client):
     rq = await client.write_coil(0, True, unit=UNIT)
     rr = await client.read_coils(0, 1, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.bits[0] == True)          # test the expected value
+    assert(rr.bits[0])          # test the expected value
 
     log.debug("Write to multiple coils and read back- test 1")
-    rq = await client.write_coils(1, [True]*8, unit=UNIT)
+    rq = await client.write_coils(1, [True] * 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
     rr = await client.read_coils(1, 21, unit=UNIT)
     assert(rr.function_code < 0x80)     # test that we are not an error
-    resp = [True]*21
+    resp = [True] * 21
 
     # If the returned output quantity is not a multiple of eight,
     # the remaining bits in the final data byte will be padded with zeros
     # (toward the high order end of the byte).
 
-    resp.extend([False]*3)
+    resp.extend([False] * 3)
     assert(rr.bits == resp)         # test the expected value
 
     log.debug("Write to multiple coils and read back - test 2")
-    rq = await client.write_coils(1, [False]*8, unit=UNIT)
+    rq = await client.write_coils(1, [False] * 8, unit=UNIT)
     rr = await client.read_coils(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.bits == [False]*8)         # test the expected value
+    assert(rr.bits == [False] * 8)         # test the expected value
 
     log.debug("Read discrete inputs")
     rr = await client.read_discrete_inputs(0, 8, unit=UNIT)
@@ -101,27 +101,27 @@ async def start_async_test(client):
     assert(rr.registers[0] == 10)       # test the expected value
 
     log.debug("Write to multiple holding registers and read back")
-    rq = await client.write_registers(1, [10]*8, unit=UNIT)
+    rq = await client.write_registers(1, [10] * 8, unit=UNIT)
     rr = await client.read_holding_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.registers == [10]*8)      # test the expected value
+    assert(rr.registers == [10] * 8)      # test the expected value
 
     log.debug("Read input registers")
     rr = await client.read_input_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address': 1,
+        'read_count': 8,
+        'write_address': 1,
+        'write_registers': [20] * 8,
     }
     log.debug("Read write registeres simulataneously")
     rq = await client.readwrite_registers(unit=UNIT, **arguments)
     rr = await client.read_holding_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rq.registers == [20]*8)      # test the expected value
-    assert(rr.registers == [20]*8)      # test the expected value
+    assert(rq.registers == [20] * 8)      # test the expected value
+    assert(rr.registers == [20] * 8)      # test the expected value
     await asyncio.sleep(1)
 
 

--- a/examples/common/async_asyncio_serial_client.py
+++ b/examples/common/async_asyncio_serial_client.py
@@ -44,9 +44,9 @@ async def start_async_test(client):
     # which defaults to `0x00`
     # ----------------------------------------------------------------------- #
     try:
-    # ----------------------------------------------------------------------- #
+        # ----------------------------------------------------------------------- #
         # example requests
-    # ----------------------------------------------------------------------- #
+        # ----------------------------------------------------------------------- #
         # simply call the methods that you would like to use.
         # An example session is displayed below along with some assert checks.
         # Note that some modbus implementations differentiate holding/
@@ -56,32 +56,32 @@ async def start_async_test(client):
         # so a change to one is a change to the other.
         # Keep both of these cases in mind when testing as the following will
         # _only_ pass with the supplied asynchronous modbus server (script supplied).
-    # ----------------------------------------------------------------------- #
+        # ----------------------------------------------------------------------- #
         log.debug("Write to a Coil and read back")
         rq = await client.write_coil(0, True, unit=UNIT)
         rr = await client.read_coils(0, 1, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
-        assert(rr.bits[0] == True)          # test the expected value
+        assert(rr.bits[0])                  # test the expected value
 
         log.debug("Write to multiple coils and read back- test 1")
-        rq = await client.write_coils(1, [True]*8, unit=UNIT)
+        rq = await client.write_coils(1, [True] * 8, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
         rr = await client.read_coils(1, 21, unit=UNIT)
         assert(rr.function_code < 0x80)     # test that we are not an error
-        resp = [True]*21
+        resp = [True] * 21
 
         # If the returned output quantity is not a multiple of eight,
         # the remaining bits in the final data byte will be padded with zeros
         # (toward the high order end of the byte).
 
-        resp.extend([False]*3)
+        resp.extend([False] * 3)
         assert(rr.bits == resp)         # test the expected value
 
         log.debug("Write to multiple coils and read back - test 2")
-        rq = await client.write_coils(1, [False]*8, unit=UNIT)
+        rq = await client.write_coils(1, [False] * 8, unit=UNIT)
         rr = await client.read_coils(1, 8, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
-        assert(rr.bits == [False]*8)         # test the expected value
+        assert(rr.bits == [False] * 8)         # test the expected value
 
         log.debug("Read discrete inputs")
         rr = await client.read_discrete_inputs(0, 8, unit=UNIT)
@@ -94,27 +94,27 @@ async def start_async_test(client):
         assert(rr.registers[0] == 10)       # test the expected value
 
         log.debug("Write to multiple holding registers and read back")
-        rq = await client.write_registers(1, [10]*8, unit=UNIT)
+        rq = await client.write_registers(1, [10] * 8, unit=UNIT)
         rr = await client.read_holding_registers(1, 8, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
-        assert(rr.registers == [10]*8)      # test the expected value
+        assert(rr.registers == [10] * 8)      # test the expected value
 
         log.debug("Read input registers")
         rr = await client.read_input_registers(1, 8, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
 
         arguments = {
-            'read_address':    1,
-            'read_count':      8,
-            'write_address':   1,
-            'write_registers': [20]*8,
+            'read_address': 1,
+            'read_count': 8,
+            'write_address': 1,
+            'write_registers': [20] * 8,
         }
         log.debug("Read write registers simulataneously")
         rq = await client.readwrite_registers(unit=UNIT, **arguments)
         rr = await client.read_holding_registers(1, 8, unit=UNIT)
         assert(rq.function_code < 0x80)     # test that we are not an error
-        assert(rq.registers == [20]*8)      # test the expected value
-        assert(rr.registers == [20]*8)      # test the expected value
+        assert(rq.registers == [20] * 8)      # test the expected value
+        assert(rr.registers == [20] * 8)      # test the expected value
     except Exception as e:
         log.exception(e)
         client.transport.close()
@@ -132,4 +132,3 @@ if __name__ == '__main__':
                                 baudrate=9600, method="rtu")
     loop.run_until_complete(start_async_test(client.protocol))
     loop.close()
-

--- a/examples/common/async_tornado_client.py
+++ b/examples/common/async_tornado_client.py
@@ -81,12 +81,12 @@ def beginAsynchronousTest(client, protocol):
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)          # test the expected value
 
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_coils(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)         # test the expected value
 
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_discrete_inputs(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)         # test the expected value
@@ -96,20 +96,20 @@ def beginAsynchronousTest(client, protocol):
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)       # test the expected value
 
-    rq = client.write_registers(1, [10]*8, unit=UNIT)
+    rq = client.write_registers(1, [10] * 8, unit=UNIT)
     rr = client.read_input_registers(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)      # test the expected value
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address': 1,
+        'read_count': 8,
+        'write_address': 1,
+        'write_registers': [20] * 8,
     }
     rq = client.readwrite_registers(**arguments, unit=UNIT)
-    rr = client.read_input_registers(1,8, unit=UNIT)
-    dassert(rq, lambda r: r.registers == [20]*8)      # test the expected value
+    rr = client.read_input_registers(1, 8, unit=UNIT)
+    dassert(rq, lambda r: r.registers == [20] * 8)      # test the expected value
     dassert(rr, _print)      # test the expected value
 
     # -----------------------------------------------------------------------#
@@ -144,6 +144,3 @@ def callback(protocol, future):
 if __name__ == "__main__":
     protocol, future = ModbusClient(schedulers.IO_LOOP, port=5020)
     future.add_done_callback(functools.partial(callback, protocol))
-
-
-

--- a/examples/common/async_tornado_client_serial.py
+++ b/examples/common/async_tornado_client_serial.py
@@ -40,7 +40,7 @@ def dassert(future, callback):
 
     def _assertor(value):
         # by pass assertion, an error here stops the write callbacks
-        assert value  
+        assert value
 
     def on_done(f):
         exc = f.exception()
@@ -85,12 +85,12 @@ def beginAsynchronousTest(client, protocol):
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)          # test the expected value
 
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_coils(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)         # test the expected value
 
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_discrete_inputs(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)         # test the expected value
@@ -100,20 +100,20 @@ def beginAsynchronousTest(client, protocol):
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)       # test the expected value
 
-    rq = client.write_registers(1, [10]*8, unit=UNIT)
+    rq = client.write_registers(1, [10] * 8, unit=UNIT)
     rr = client.read_input_registers(1, 8, unit=UNIT)
     dassert(rq, lambda r: r.function_code < 0x80)     # test for no error
     dassert(rr, _print)      # test the expected value
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address': 1,
+        'read_count': 8,
+        'write_address': 1,
+        'write_registers': [20] * 8,
     }
     rq = client.readwrite_registers(**arguments, unit=UNIT)
-    rr = client.read_input_registers(1,8, unit=UNIT)
-    dassert(rq, lambda r: r.registers == [20]*8)      # test the expected value
+    rr = client.read_input_registers(1, 8, unit=UNIT)
+    dassert(rq, lambda r: r.registers == [20] * 8)      # test the expected value
     dassert(rr, _print)      # test the expected value
 
     # -----------------------------------------------------------------------#

--- a/examples/common/async_twisted_client.py
+++ b/examples/common/async_twisted_client.py
@@ -20,7 +20,7 @@ from pymodbus.client.asynchronous import schedulers
 # choose the requested modbus protocol
 # --------------------------------------------------------------------------- #
 
-from twisted.internet import reactor, protocol
+from twisted.internet import protocol
 
 # --------------------------------------------------------------------------- #
 # configure the client logging
@@ -98,38 +98,38 @@ def beginAsynchronousTest(client):
     rq = client.write_coil(1, True, unit=UNIT)
     rr = client.read_coils(1, 1, unit=UNIT)
     dassert(rq, lambda r: not r.isError())     # test for no error
-    dassert(rr, lambda r: r.bits[0] == True)          # test the expected value
+    dassert(rr, lambda r: r.bits[0])          # test the expected value
 
-    rq = client.write_coils(1, [True]*8, unit=UNIT)
+    rq = client.write_coils(1, [True] * 8, unit=UNIT)
     rr = client.read_coils(1, 8, unit=UNIT)
     dassert(rq, lambda r: not r.isError())     # test for no error
-    dassert(rr, lambda r: r.bits == [True]*8)        # test the expected value
+    dassert(rr, lambda r: r.bits == [True] * 8)        # test the expected value
 
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_discrete_inputs(1, 8, unit=UNIT)
     dassert(rq, lambda r: not r.isError())     # test for no error
-    dassert(rr, lambda r: r.bits == [True]*8)        # test the expected value
+    dassert(rr, lambda r: r.bits == [True] * 8)        # test the expected value
 
     rq = client.write_register(1, 10, unit=UNIT)
     rr = client.read_holding_registers(1, 1, unit=UNIT)
     dassert(rq, lambda r: not r.isError())     # test for no error
     dassert(rr, lambda r: r.registers[0] == 10)       # test the expected value
 
-    rq = client.write_registers(1, [10]*8, unit=UNIT)
+    rq = client.write_registers(1, [10] * 8, unit=UNIT)
     rr = client.read_input_registers(1, 8, unit=UNIT)
     dassert(rq, lambda r: not r.isError())     # test for no error
-    dassert(rr, lambda r: r.registers == [17]*8)      # test the expected value
+    dassert(rr, lambda r: r.registers == [17] * 8)      # test the expected value
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address': 1,
+        'read_count': 8,
+        'write_address': 1,
+        'write_registers': [20] * 8,
     }
     rq = client.readwrite_registers(arguments, unit=UNIT)
     rr = client.read_input_registers(1, 8, unit=UNIT)
-    dassert(rq, lambda r: r.registers == [20]*8)      # test the expected value
-    dassert(rr, lambda r: r.registers == [17]*8)      # test the expected value
+    dassert(rq, lambda r: r.registers == [20] * 8)      # test the expected value
+    dassert(rr, lambda r: r.registers == [17] * 8)      # test the expected value
     stopAsynchronousTest(client)
 
     # ----------------------------------------------------------------------- #
@@ -165,8 +165,5 @@ def beginAsynchronousTest(client):
 
 if __name__ == "__main__":
     protocol, deferred = AsyncModbusTCPClient(schedulers.REACTOR, port=5020)
-    # protocol, deferred = AsyncModbusUDPClient(schedulers.REACTOR, port=5020)
-                             # callback=beginAsynchronousTest,
-                             # errback=err)
     deferred.addCallback(beginAsynchronousTest)
     deferred.addErrback(err)

--- a/examples/common/async_twisted_client_serial.py
+++ b/examples/common/async_twisted_client_serial.py
@@ -27,6 +27,7 @@ STATUS_COILS = (1, 3)
 CLIENT_DELAY = 1
 UNIT = 0x01
 
+
 class ExampleProtocol(ModbusClientProtocol):
 
     def __init__(self, framer):
@@ -77,12 +78,10 @@ class ExampleProtocol(ModbusClientProtocol):
 if __name__ == "__main__":
     import time
     proto, client = AsyncModbusSerialClient(schedulers.REACTOR,
-                                            method="rtu", 
-                                            port=SERIAL_PORT, 
-                                            timeout=2, 
+                                            method="rtu",
+                                            port=SERIAL_PORT,
+                                            timeout=2,
                                             proto_cls=ExampleProtocol)
     proto.start()
     time.sleep(10)  # Wait for operation to complete
     # proto.stop()
-
-

--- a/examples/common/asynchronous_processor.py
+++ b/examples/common/asynchronous_processor.py
@@ -188,4 +188,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/examples/common/asynchronous_server.py
+++ b/examples/common/asynchronous_server.py
@@ -7,25 +7,25 @@ The asynchronous server is a high performance implementation using the
 twisted library as its backend.  This allows it to scale to many thousands
 of nodes which can be helpful for testing monitoring software.
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
 from pymodbus.server.asynchronous import StartTcpServer
-from pymodbus.server.asynchronous import StartUdpServer
-from pymodbus.server.asynchronous import StartSerialServer
+# from pymodbus.server.asynchronous import StartUdpServer
+# from pymodbus.server.asynchronous import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-from pymodbus.transaction import (ModbusRtuFramer,
-                                  ModbusAsciiFramer,
-                                  ModbusBinaryFramer)
+# from pymodbus.transaction import (ModbusRtuFramer,
+#                                   ModbusAsciiFramer,
+#                                   ModbusBinaryFramer)
 from custom_message import CustomModbusRequest
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the service logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 import logging
 FORMAT = ('%(asctime)-15s %(threadName)-15s'
           ' %(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
@@ -35,9 +35,9 @@ log.setLevel(logging.DEBUG)
 
 
 def run_async_server():
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # initialize your data store
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # The datastores only respond to the addresses that they are initialized to
     # Therefore, if you initialize a DataBlock to addresses from 0x00 to 0xFF,
     # a request to 0x100 will respond with an invalid address exception.
@@ -88,21 +88,21 @@ def run_async_server():
     # will map to (1-8)::
     #
     #     store = ModbusSlaveContext(..., zero_mode=True)
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     store = ModbusSlaveContext(
-        di=ModbusSequentialDataBlock(0, [17]*100),
-        co=ModbusSequentialDataBlock(0, [17]*100),
-        hr=ModbusSequentialDataBlock(0, [17]*100),
-        ir=ModbusSequentialDataBlock(0, [17]*100))
+        di=ModbusSequentialDataBlock(0, [17] * 100),
+        co=ModbusSequentialDataBlock(0, [17] * 100),
+        hr=ModbusSequentialDataBlock(0, [17] * 100),
+        ir=ModbusSequentialDataBlock(0, [17] * 100))
     store.register(CustomModbusRequest.function_code, 'cm',
                    ModbusSequentialDataBlock(0, [17] * 100))
     context = ModbusServerContext(slaves=store, single=True)
-    
-    # ----------------------------------------------------------------------- # 
+
+    # ----------------------------------------------------------------------- #
     # initialize the server information
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # If you don't set this or any fields, they are defaulted to empty strings.
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     identity = ModbusDeviceIdentification()
     identity.VendorName = 'Pymodbus'
     identity.ProductCode = 'PM'
@@ -110,10 +110,10 @@ def run_async_server():
     identity.ProductName = 'Pymodbus Server'
     identity.ModelName = 'Pymodbus Server'
     identity.MajorMinorRevision = version.short()
-    
-    # ----------------------------------------------------------------------- # 
+
+    # ----------------------------------------------------------------------- #
     # run the server you want
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
 
     # TCP Server
 
@@ -149,4 +149,3 @@ def run_async_server():
 
 if __name__ == "__main__":
     run_async_server()
-

--- a/examples/common/asynchronous_server.py
+++ b/examples/common/asynchronous_server.py
@@ -12,15 +12,10 @@ of nodes which can be helpful for testing monitoring software.
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
 from pymodbus.server.asynchronous import StartTcpServer
-# from pymodbus.server.asynchronous import StartUdpServer
-# from pymodbus.server.asynchronous import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-# from pymodbus.transaction import (ModbusRtuFramer,
-#                                   ModbusAsciiFramer,
-#                                   ModbusBinaryFramer)
 from custom_message import CustomModbusRequest
 
 # --------------------------------------------------------------------------- #

--- a/examples/common/asyncio_server.py
+++ b/examples/common/asyncio_server.py
@@ -14,16 +14,11 @@ twisted is just not feasible. What follows is an example of its use:
 import asyncio
 from pymodbus.version import version
 from pymodbus.server.async_io import StartTcpServer
-# from pymodbus.server.async_io import StartTlsServer
-# from pymodbus.server.async_io import StartUdpServer
-# from pymodbus.server.async_io import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 from pymodbus.datastore import ModbusSequentialDataBlock
-# from pymodbus.datastore import ModbusSparseDataBlock
 
-# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 # --------------------------------------------------------------------------- #
 # configure the service logging
 # --------------------------------------------------------------------------- #

--- a/examples/common/asyncio_server.py
+++ b/examples/common/asyncio_server.py
@@ -14,15 +14,16 @@ twisted is just not feasible. What follows is an example of its use:
 import asyncio
 from pymodbus.version import version
 from pymodbus.server.async_io import StartTcpServer
-from pymodbus.server.async_io import StartTlsServer
-from pymodbus.server.async_io import StartUdpServer
-from pymodbus.server.async_io import StartSerialServer
+# from pymodbus.server.async_io import StartTlsServer
+# from pymodbus.server.async_io import StartUdpServer
+# from pymodbus.server.async_io import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
-from pymodbus.datastore import ModbusSequentialDataBlock, ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
+from pymodbus.datastore import ModbusSequentialDataBlock
+# from pymodbus.datastore import ModbusSparseDataBlock
 
-from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 # --------------------------------------------------------------------------- #
 # configure the service logging
 # --------------------------------------------------------------------------- #
@@ -90,10 +91,10 @@ async def run_server():
     #     store = ModbusSlaveContext(..., zero_mode=True)
     # ----------------------------------------------------------------------- #
     store = ModbusSlaveContext(
-        di=ModbusSequentialDataBlock(0, [17]*100),
-        co=ModbusSequentialDataBlock(0, [17]*100),
-        hr=ModbusSequentialDataBlock(0, [17]*100),
-        ir=ModbusSequentialDataBlock(0, [17]*100))
+        di=ModbusSequentialDataBlock(0, [17] * 100),
+        co=ModbusSequentialDataBlock(0, [17] * 100),
+        hr=ModbusSequentialDataBlock(0, [17] * 100),
+        ir=ModbusSequentialDataBlock(0, [17] * 100))
 
     context = ModbusServerContext(slaves=store, single=True)
 
@@ -165,4 +166,3 @@ async def run_server():
 
 if __name__ == "__main__":
     asyncio.run(run_server())
-

--- a/examples/common/callback_server.py
+++ b/examples/common/callback_server.py
@@ -15,7 +15,6 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
 
 # --------------------------------------------------------------------------- #

--- a/examples/common/callback_server.py
+++ b/examples/common/callback_server.py
@@ -15,7 +15,7 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
 
 # --------------------------------------------------------------------------- #
@@ -88,7 +88,8 @@ def device_writer(queue):
         device, value = queue.get()
         scaled = rescale_value(value[0])
         log.debug("Write(%s) = %s" % (device, value))
-        if not device: continue
+        if not device:
+            continue
         # do any logic here to update your devices
 
 # --------------------------------------------------------------------------- #
@@ -100,8 +101,8 @@ def read_device_map(path):
     """ A helper method to read the device
     path to address mapping from file::
 
-       0x0001,/dev/device1 
-       0x0002,/dev/device2 
+       0x0001,/dev/device1
+       0x0002,/dev/device2
 
     :param path: The path to the input file
     :returns: The input mapping file
@@ -145,4 +146,3 @@ def run_callback_server():
 
 if __name__ == "__main__":
     run_callback_server()
-

--- a/examples/common/changing_framers.py
+++ b/examples/common/changing_framers.py
@@ -25,8 +25,8 @@ from pymodbus.client.sync import ModbusTcpClient as ModbusClient
 # --------------------------------------------------------------------------- #
 from pymodbus.transaction import ModbusSocketFramer as ModbusFramer
 # from pymodbus.transaction import ModbusRtuFramer as ModbusFramer
-#from pymodbus.transaction import ModbusBinaryFramer as ModbusFramer
-#from pymodbus.transaction import ModbusAsciiFramer as ModbusFramer
+# from pymodbus.transaction import ModbusBinaryFramer as ModbusFramer
+# from pymodbus.transaction import ModbusAsciiFramer as ModbusFramer
 
 # --------------------------------------------------------------------------- #
 # configure the client logging
@@ -47,9 +47,9 @@ if __name__ == "__main__":
     # perform your requests
     # ----------------------------------------------------------------------- #
     rq = client.write_coil(1, True)
-    rr = client.read_coils(1,1)
+    rr = client.read_coils(1, 1)
     assert(not rq.isError())     # test that we are not an error
-    assert(rr.bits[0] == True)          # test the expected value
+    assert(rr.bits[0])           # test the expected value
 
     # ----------------------------------------------------------------------- #
     # close the client

--- a/examples/common/custom_datablock.py
+++ b/examples/common/custom_datablock.py
@@ -6,7 +6,7 @@ Pymodbus Server With Custom Datablock Side Effect
 This is an example of performing custom logic after a value has been
 written to the datastore.
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the modbus libraries we need
 # --------------------------------------------------------------------------- #
 from __future__ import print_function
@@ -15,20 +15,20 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the service logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 
 import logging
 logging.basicConfig()
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # create your custom data block here
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 
 
 class CustomDataBlock(ModbusSparseDataBlock):
@@ -52,11 +52,11 @@ class CustomDataBlock(ModbusSparseDataBlock):
 
 
 def run_custom_db_server():
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # initialize your data store
-    # ----------------------------------------------------------------------- # 
-    block  = CustomDataBlock([0]*100)
-    store  = ModbusSlaveContext(di=block, co=block, hr=block, ir=block)
+    # ----------------------------------------------------------------------- #
+    block = CustomDataBlock([0] * 100)
+    store = ModbusSlaveContext(di=block, co=block, hr=block, ir=block)
     context = ModbusServerContext(slaves=store, single=True)
 
     # ----------------------------------------------------------------------- #
@@ -82,5 +82,3 @@ def run_custom_db_server():
 
 if __name__ == "__main__":
     run_custom_db_server()
-
-

--- a/examples/common/custom_datablock.py
+++ b/examples/common/custom_datablock.py
@@ -15,7 +15,6 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
 # --------------------------------------------------------------------------- #
 # configure the service logging

--- a/examples/common/custom_message.py
+++ b/examples/common/custom_message.py
@@ -31,7 +31,7 @@ log.setLevel(logging.DEBUG)
 # --------------------------------------------------------------------------- #
 # The following is simply a read coil request that always reads 16 coils.
 # Since the function code is already registered with the decoder factory,
-# this will be decoded as a read coil response. If you implement a new 
+# this will be decoded as a read coil response. If you implement a new
 # method that is not currently implemented, you must register the request
 # and response with a ClientDecoder factory.
 # --------------------------------------------------------------------------- #
@@ -44,7 +44,7 @@ class CustomModbusResponse(ModbusResponse):
     def __init__(self, values=None, **kwargs):
         ModbusResponse.__init__(self, **kwargs)
         self.values = values or []
-    
+
     def encode(self):
         """ Encodes response pdu
 

--- a/examples/common/custom_message_async_clients.py
+++ b/examples/common/custom_message_async_clients.py
@@ -31,7 +31,7 @@ log.setLevel(logging.DEBUG)
 # --------------------------------------------------------------------------- #
 # The following is simply a read coil request that always reads 16 coils.
 # Since the function code is already registered with the decoder factory,
-# this will be decoded as a read coil response. If you implement a new 
+# this will be decoded as a read coil response. If you implement a new
 # method that is not currently implemented, you must register the request
 # and response with a ClientDecoder factory.
 # --------------------------------------------------------------------------- #
@@ -44,7 +44,7 @@ class CustomModbusResponse(ModbusResponse):
     def __init__(self, values=None, **kwargs):
         ModbusResponse.__init__(self, **kwargs)
         self.values = values or []
-    
+
     def encode(self):
         """ Encodes response pdu
 

--- a/examples/common/custom_synchronous_server.py
+++ b/examples/common/custom_synchronous_server.py
@@ -113,4 +113,3 @@ def run_server():
 
 if __name__ == "__main__":
     run_server()
-

--- a/examples/common/dbstore_update_server.py
+++ b/examples/common/dbstore_update_server.py
@@ -22,7 +22,7 @@ from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.datastore.database import SqlSlaveContext
-from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 import random
 
 # --------------------------------------------------------------------------- #
@@ -50,10 +50,10 @@ def updating_writer(a):
     :param arguments: The input arguments to the call
     """
     log.debug("Updating the database context")
-    context  = a[0]
-    readfunction = 0x03 # read holding registers
+    context = a[0]
+    readfunction = 0x03  # read holding registers
     writefunction = 0x10
-    slave_id = 0x01 # slave address
+    slave_id = 0x01  # slave address
     count = 50
 
     # import pdb; pdb.set_trace()
@@ -101,5 +101,3 @@ def run_dbstore_update_server():
 
 if __name__ == "__main__":
     run_dbstore_update_server()
-
-

--- a/examples/common/dbstore_update_server.py
+++ b/examples/common/dbstore_update_server.py
@@ -22,7 +22,6 @@ from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.datastore.database import SqlSlaveContext
-# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 import random
 
 # --------------------------------------------------------------------------- #

--- a/examples/common/modbus_logging.py
+++ b/examples/common/modbus_logging.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     log = logging.getLogger('pymodbus')
     log.setLevel(logging.ERROR)
     handlers = [
-        Handlers.RotatingFileHandler("logfile", maxBytes=1024*1024),
+        Handlers.RotatingFileHandler("logfile", maxBytes=1024 * 1024),
         Handlers.SMTPHandler("mx.host.com",
                              "pymodbus@host.com",
                              ["support@host.com"],
@@ -43,4 +43,3 @@ if __name__ == "__main__":
         Handlers.DatagramHandler('localhost', 12345),
     ]
     [log.addHandler(h) for h in handlers]
-

--- a/examples/common/modbus_payload.py
+++ b/examples/common/modbus_payload.py
@@ -12,9 +12,9 @@ from pymodbus.client.sync import ModbusTcpClient as ModbusClient
 from pymodbus.compat import iteritems
 from collections import OrderedDict
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the client logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 
 import logging
 FORMAT = ('%(asctime)-15s %(threadName)-15s'
@@ -151,7 +151,7 @@ def run_binary_payload_ex():
         # ----------------------------------------------------------------------- #
         address = 0x0
         count = len(payload)
-        result = client.read_holding_registers(address, count,  unit=1)
+        result = client.read_holding_registers(address, count, unit=1)
         print("-" * 60)
         print("Registers")
         print("-" * 60)
@@ -162,11 +162,10 @@ def run_binary_payload_ex():
                                                      wordorder=wo)
 
         assert decoder._byteorder == builder._byteorder, \
-                "Make sure byteorder is consistent between BinaryPayloadBuilder and BinaryPayloadDecoder"
+               "Make sure byteorder is consistent between BinaryPayloadBuilder and BinaryPayloadDecoder"
 
         assert decoder._wordorder == builder._wordorder, \
-                "Make sure wordorder is consistent between BinaryPayloadBuilder and BinaryPayloadDecoder"
-
+               "Make sure wordorder is consistent between BinaryPayloadBuilder and BinaryPayloadDecoder"
 
         decoded = OrderedDict([
             ('string', decoder.decode_string(len(strng))),

--- a/examples/common/modbus_payload_server.py
+++ b/examples/common/modbus_payload_server.py
@@ -6,26 +6,26 @@ Pymodbus Server Payload Example
 If you want to initialize a server context with a complicated memory
 layout, you can actually use the payload builder.
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the various server implementations
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 from pymodbus.version import version
 from pymodbus.server.sync import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the payload builder
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 
 from pymodbus.constants import Endian
-from pymodbus.payload import BinaryPayloadDecoder
+# from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the service logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 import logging
 FORMAT = ('%(asctime)-15s %(threadName)-15s'
           ' %(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
@@ -58,17 +58,16 @@ def run_payload_server():
     builder.add_64bit_float(123.45)
     builder.add_64bit_float(-123.45)
 
-    
     # ----------------------------------------------------------------------- #
     # use that payload in the data store
     # ----------------------------------------------------------------------- #
     # Here we use the same reference block for each underlying store.
     # ----------------------------------------------------------------------- #
-    
+
     block = ModbusSequentialDataBlock(1, builder.to_registers())
     store = ModbusSlaveContext(di=block, co=block, hr=block, ir=block)
     context = ModbusServerContext(slaves=store, single=True)
-    
+
     # ----------------------------------------------------------------------- #
     # initialize the server information
     # ----------------------------------------------------------------------- #
@@ -85,8 +84,7 @@ def run_payload_server():
     # run the server you want
     # ----------------------------------------------------------------------- #
     StartTcpServer(context, identity=identity, address=("localhost", 5020))
-    
+
 
 if __name__ == "__main__":
     run_payload_server()
-

--- a/examples/common/modbus_payload_server.py
+++ b/examples/common/modbus_payload_server.py
@@ -20,7 +20,6 @@ from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 # --------------------------------------------------------------------------- #
 
 from pymodbus.constants import Endian
-# from pymodbus.payload import BinaryPayloadDecoder
 from pymodbus.payload import BinaryPayloadBuilder
 
 # --------------------------------------------------------------------------- #

--- a/examples/common/performance.py
+++ b/examples/common/performance.py
@@ -6,14 +6,14 @@ Pymodbus Performance Example
 The following is an quick performance check of the synchronous
 modbus client.
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the necessary modules
 # --------------------------------------------------------------------------- #
 from __future__ import print_function
-import logging, os
+import os
 from time import time
 from pymodbus.client.sync import ModbusTcpClient
-from pymodbus.client.sync import ModbusSerialClient
+# from pymodbus.client.sync import ModbusSerialClient
 
 try:
     from multiprocessing import log_to_stderr
@@ -22,35 +22,35 @@ except ImportError:
     logging.basicConfig()
     log_to_stderr = logging.getLogger
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # choose between threads or processes
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 
-#from multiprocessing import Process as Worker
-from threading import Thread as Worker
+# from multiprocessing import Process as Worker
+# from threading import Thread as Worker
 from threading import Lock
 _thread_lock = Lock()
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # initialize the test
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Modify the parameters below to control how we are testing the client:
 #
 # * workers - the number of workers to use at once
 # * cycles  - the total number of requests to send
 # * host    - the host to send the requests to
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 workers = 10
 cycles = 1000
 host = '127.0.0.1'
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # perform the test
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # This test is written such that it can be used by many threads of processes
 # although it should be noted that there are performance penalties
 # associated with each strategy.
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 def single_client_test(host, cycles):
     """ Performs a single threaded test of a synchronous
     client against the specified host
@@ -72,7 +72,7 @@ def single_client_test(host, cycles):
             # with _thread_lock:
             client.read_holding_registers(10, 123, unit=1)
             count += 1
-    except:
+    except Exception:
         logger.exception("failed to run test successfully")
     logger.debug("finished worker: %d" % os.getpid())
 
@@ -109,9 +109,9 @@ def thread_pool_exe_test(fn, args):
             future.result()
     return start
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # run our test and check results
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # We shard the total number of requests to perform between the number of
 # threads that was specified. We then start all the threads and block on
 # them to finish. This may need to switch to another mechanism to signal
@@ -144,5 +144,5 @@ if __name__ == "__main__":
         stop = time()
         print("%d requests/second" % ((1.0 * cycles) / (stop - start)))
         print("time taken to complete %s cycle by "
-              "%s workers is %s seconds" % (cycles, workers, stop-start))
+              "%s workers is %s seconds" % (cycles, workers, stop - start))
         print()

--- a/examples/common/performance.py
+++ b/examples/common/performance.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 import os
 from time import time
 from pymodbus.client.sync import ModbusTcpClient
-# from pymodbus.client.sync import ModbusSerialClient
 
 try:
     from multiprocessing import log_to_stderr

--- a/examples/common/synchronous_client.py
+++ b/examples/common/synchronous_client.py
@@ -84,7 +84,6 @@ def run_sync_client():
     rr = client.read_coils(1, 1, unit=UNIT)
     log.debug(rr)
 
-
     # ----------------------------------------------------------------------- #
     # example requests
     # ----------------------------------------------------------------------- #
@@ -102,28 +101,28 @@ def run_sync_client():
     rr = client.read_coils(0, 1, unit=UNIT)
     assert(not rq.isError())     # test that we are not an error
     assert(not rr.isError())     # test that we are not an error
-    assert(rr.bits[0] == True)          # test the expected value
+    assert(rr.bits[0])          # test the expected value
 
     log.debug("Write to multiple coils and read back- test 1")
-    rq = client.write_coils(1, [True]*8, unit=UNIT)
+    rq = client.write_coils(1, [True] * 8, unit=UNIT)
     rr = client.read_coils(1, 21, unit=UNIT)
     assert(not rq.isError())     # test that we are not an error
     assert(not rr.isError())     # test that we are not an error
-    resp = [True]*21
+    resp = [True] * 21
 
     # If the returned output quantity is not a multiple of eight,
     # the remaining bits in the final data byte will be padded with zeros
     # (toward the high order end of the byte).
 
-    resp.extend([False]*3)
+    resp.extend([False] * 3)
     assert(rr.bits == resp)         # test the expected value
 
     log.debug("Write to multiple coils and read back - test 2")
-    rq = client.write_coils(1, [False]*8, unit=UNIT)
+    rq = client.write_coils(1, [False] * 8, unit=UNIT)
     rr = client.read_coils(1, 8, unit=UNIT)
     assert(not rq.isError())     # test that we are not an error
     assert(not rr.isError())     # test that we are not an error
-    assert(rr.bits == [False]*8)         # test the expected value
+    assert(rr.bits == [False] * 8)         # test the expected value
 
     log.debug("Read discrete inputs")
     rr = client.read_discrete_inputs(0, 8, unit=UNIT)
@@ -137,29 +136,29 @@ def run_sync_client():
     assert(rr.registers[0] == 10)       # test the expected value
 
     log.debug("Write to multiple holding registers and read back")
-    rq = client.write_registers(1, [10]*8, unit=UNIT)
+    rq = client.write_registers(1, [10] * 8, unit=UNIT)
     rr = client.read_holding_registers(1, 8, unit=UNIT)
     assert(not rq.isError())     # test that we are not an error
     assert(not rr.isError())     # test that we are not an error
-    assert(rr.registers == [10]*8)      # test the expected value
+    assert(rr.registers == [10] * 8)      # test the expected value
 
     log.debug("Read input registers")
     rr = client.read_input_registers(1, 8, unit=UNIT)
     assert(not rr.isError())     # test that we are not an error
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address':    1, # noqa E221
+        'read_count':      8, # noqa E221
+        'write_address':   1, # noqa E221
+        'write_registers': [20] * 8,
     }
     log.debug("Read write registeres simulataneously")
     rq = client.readwrite_registers(unit=UNIT, **arguments)
     rr = client.read_holding_registers(1, 8, unit=UNIT)
     assert(not rq.isError())     # test that we are not an error
     assert(not rr.isError())     # test that we are not an error
-    assert(rq.registers == [20]*8)      # test the expected value
-    assert(rr.registers == [20]*8)      # test the expected value
+    assert(rq.registers == [20] * 8)      # test the expected value
+    assert(rr.registers == [20] * 8)      # test the expected value
 
     # ----------------------------------------------------------------------- #
     # close the client

--- a/examples/common/synchronous_client_ext.py
+++ b/examples/common/synchronous_client_ext.py
@@ -15,7 +15,7 @@ modbus protocol.
 from pymodbus.client.sync import ModbusSerialClient as ModbusClient
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the extended messages to perform
 # --------------------------------------------------------------------------- #
 from pymodbus.diag_message import *
@@ -46,7 +46,7 @@ def execute_extended_requests():
     #
     # It should be noted that you can supply an ipv4 or an ipv6 host address
     # for both the UDP and TCP clients.
-    # ------------------------------------------------------------------------# 
+    # ------------------------------------------------------------------------#
     client = ModbusClient(method='rtu', port="/dev/ptyp0")
     # client = ModbusClient(method='ascii', port="/dev/ptyp0")
     # client = ModbusClient(method='binary', port="/dev/ptyp0")
@@ -232,8 +232,3 @@ def execute_extended_requests():
 
 if __name__ == "__main__":
     execute_extended_requests()
-
-
-
-
-

--- a/examples/common/synchronous_server.py
+++ b/examples/common/synchronous_server.py
@@ -12,17 +12,11 @@ twisted is just not feasible. What follows is an example of its use:
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
-# from pymodbus.server.sync import StartTcpServer
-# from pymodbus.server.sync import StartTlsServer
-# from pymodbus.server.sync import StartUdpServer
-# from pymodbus.server.sync import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
-# from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 
-# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 # --------------------------------------------------------------------------- #
 # configure the service logging
 # --------------------------------------------------------------------------- #

--- a/examples/common/synchronous_server.py
+++ b/examples/common/synchronous_server.py
@@ -12,16 +12,17 @@ twisted is just not feasible. What follows is an example of its use:
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
-from pymodbus.server.sync import StartTcpServer
-from pymodbus.server.sync import StartTlsServer
-from pymodbus.server.sync import StartUdpServer
-from pymodbus.server.sync import StartSerialServer
+# from pymodbus.server.sync import StartTcpServer
+# from pymodbus.server.sync import StartTlsServer
+# from pymodbus.server.sync import StartUdpServer
+# from pymodbus.server.sync import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
-from pymodbus.datastore import ModbusSequentialDataBlock, ModbusSparseDataBlock
+from pymodbus.datastore import ModbusSequentialDataBlock
+# from pymodbus.datastore import ModbusSparseDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 
-from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 # --------------------------------------------------------------------------- #
 # configure the service logging
 # --------------------------------------------------------------------------- #
@@ -89,10 +90,10 @@ def run_server():
     #     store = ModbusSlaveContext(..., zero_mode=True)
     # ----------------------------------------------------------------------- #
     store = ModbusSlaveContext(
-        di=ModbusSequentialDataBlock(0, [17]*100),
-        co=ModbusSequentialDataBlock(0, [17]*100),
-        hr=ModbusSequentialDataBlock(0, [17]*100),
-        ir=ModbusSequentialDataBlock(0, [17]*100))
+        di=ModbusSequentialDataBlock(0, [17] * 100),
+        co=ModbusSequentialDataBlock(0, [17] * 100),
+        hr=ModbusSequentialDataBlock(0, [17] * 100),
+        ir=ModbusSequentialDataBlock(0, [17] * 100))
 
     context = ModbusServerContext(slaves=store, single=True)
 
@@ -151,4 +152,3 @@ def run_server():
 
 if __name__ == "__main__":
     run_server()
-

--- a/examples/common/updating_server.py
+++ b/examples/common/updating_server.py
@@ -20,7 +20,6 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
 # --------------------------------------------------------------------------- #
 # import the twisted libraries we need

--- a/examples/common/updating_server.py
+++ b/examples/common/updating_server.py
@@ -20,7 +20,7 @@ from pymodbus.server.asynchronous import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusAsciiFramer
 
 # --------------------------------------------------------------------------- #
 # import the twisted libraries we need
@@ -59,20 +59,20 @@ def updating_writer(a):
 
 
 def run_updating_server():
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # initialize your data store
-    # ----------------------------------------------------------------------- # 
-    
+    # ----------------------------------------------------------------------- #
+
     store = ModbusSlaveContext(
-        di=ModbusSequentialDataBlock(0, [17]*100),
-        co=ModbusSequentialDataBlock(0, [17]*100),
-        hr=ModbusSequentialDataBlock(0, [17]*100),
-        ir=ModbusSequentialDataBlock(0, [17]*100))
+        di=ModbusSequentialDataBlock(0, [17] * 100),
+        co=ModbusSequentialDataBlock(0, [17] * 100),
+        hr=ModbusSequentialDataBlock(0, [17] * 100),
+        ir=ModbusSequentialDataBlock(0, [17] * 100))
     context = ModbusServerContext(slaves=store, single=True)
-    
-    # ----------------------------------------------------------------------- # 
+
+    # ----------------------------------------------------------------------- #
     # initialize the server information
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     identity = ModbusDeviceIdentification()
     identity.VendorName = 'pymodbus'
     identity.ProductCode = 'PM'
@@ -80,13 +80,13 @@ def run_updating_server():
     identity.ProductName = 'pymodbus Server'
     identity.ModelName = 'pymodbus Server'
     identity.MajorMinorRevision = version.short()
-    
-    # ----------------------------------------------------------------------- # 
+
+    # ----------------------------------------------------------------------- #
     # run the server you want
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     time = 5  # 5 seconds delay
     loop = LoopingCall(f=updating_writer, a=(context,))
-    loop.start(time, now=False) # initially delay by time
+    loop.start(time, now=False)  # initially delay by time
     StartTcpServer(context, identity=identity, address=("localhost", 5020))
 
 

--- a/examples/contrib/asynchronous_asyncio_modbus_tls_client.py
+++ b/examples/contrib/asynchronous_asyncio_modbus_tls_client.py
@@ -29,7 +29,7 @@ sslctx.check_hostname = True
 async def start_async_test(client):
     result = await client.read_coils(1, 8)
     print(result.bits)
-    await client.write_coils(1, [False]*3)
+    await client.write_coils(1, [False] * 3)
     result = await client.read_coils(1, 8)
     print(result.bits)
 

--- a/examples/contrib/asynchronous_asyncio_serial_client.py
+++ b/examples/contrib/asynchronous_asyncio_serial_client.py
@@ -43,28 +43,27 @@ async def start_async_test(client):
     rq = await client.write_coil(0, True, unit=UNIT)
     rr = await client.read_coils(0, 1, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.bits[0] == True)          # test the expected value
+    assert(rr.bits[0])          # test the expected value
 
     log.debug("Write to multiple coils and read back- test 1")
-    rq = await client.write_coils(1, [True]*8, unit=UNIT)
+    rq = await client.write_coils(1, [True] * 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
     rr = await client.read_coils(1, 21, unit=UNIT)
     assert(rr.function_code < 0x80)     # test that we are not an error
-    resp = [True]*21
+    resp = [True] * 21
 
     # If the returned output quantity is not a multiple of eight,
     # the remaining bits in the final data byte will be padded with zeros
     # (toward the high order end of the byte).
 
-    resp.extend([False]*3)
+    resp.extend([False] * 3)
     assert(rr.bits == resp)         # test the expected value
 
     log.debug("Write to multiple coils and read back - test 2")
-    rq = await client.write_coils(1, [False]*8, unit=UNIT)
+    rq = await client.write_coils(1, [False] * 8, unit=UNIT)
     rr = await client.read_coils(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.bits == [False]*8)         # test the expected value
-
+    assert(rr.bits == [False] * 8)         # test the expected value
 
     log.debug("Read discrete inputs")
     rr = await client.read_discrete_inputs(0, 8, unit=UNIT)
@@ -77,27 +76,27 @@ async def start_async_test(client):
     assert(rr.registers[0] == 10)       # test the expected value
 
     log.debug("Write to multiple holding registers and read back")
-    rq = await client.write_registers(1, [10]*8, unit=UNIT)
+    rq = await client.write_registers(1, [10] * 8, unit=UNIT)
     rr = await client.read_holding_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rr.registers == [10]*8)      # test the expected value
+    assert(rr.registers == [10] * 8)      # test the expected value
 
     log.debug("Read input registers")
     rr = await client.read_input_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
 
     arguments = {
-        'read_address':    1,
-        'read_count':      8,
-        'write_address':   1,
-        'write_registers': [20]*8,
+        'read_address':    1,  # noqa E221
+        'read_count':      8,  # noqa E221
+        'write_address':   1,  # noqa E221
+        'write_registers': [20] * 8,
     }
     log.debug("Read write registeres simulataneously")
     rq = await client.readwrite_registers(unit=UNIT, **arguments)
     rr = await client.read_holding_registers(1, 8, unit=UNIT)
     assert(rq.function_code < 0x80)     # test that we are not an error
-    assert(rq.registers == [20]*8)      # test the expected value
-    assert(rr.registers == [20]*8)      # test the expected value
+    assert(rq.registers == [20] * 8)      # test the expected value
+    assert(rr.registers == [20] * 8)      # test the expected value
 
 
 # create_serial_connection doesn't allow to pass arguments

--- a/examples/contrib/bcd_payload.py
+++ b/examples/contrib/bcd_payload.py
@@ -7,7 +7,6 @@ that can be used in the pymodbus library. Below is a
 simple binary coded decimal builder and decoder.
 """
 from struct import pack
-# from struct import unpack
 from pymodbus.constants import Endian
 from pymodbus.interfaces import IPayloadBuilder
 from pymodbus.utilities import pack_bitstring

--- a/examples/contrib/bcd_payload.py
+++ b/examples/contrib/bcd_payload.py
@@ -3,10 +3,11 @@ Modbus BCD Payload Builder
 -----------------------------------------------------------
 
 This is an example of building a custom payload builder
-that can be used in the pymodbus library. Below is a 
+that can be used in the pymodbus library. Below is a
 simple binary coded decimal builder and decoder.
 """
-from struct import pack, unpack
+from struct import pack
+# from struct import unpack
 from pymodbus.constants import Endian
 from pymodbus.interfaces import IPayloadBuilder
 from pymodbus.utilities import pack_bitstring
@@ -77,7 +78,7 @@ class BcdPayloadBuilder(IPayloadBuilder):
         :param endian: The endianess of the payload
         """
         self._payload = payload or []
-        self._endian  = endian
+        self._endian = endian
 
     def __str__(self):
         """ Return the payload buffer as a string
@@ -102,7 +103,7 @@ class BcdPayloadBuilder(IPayloadBuilder):
         string = str(self)
         length = len(string)
         string = string + ('\x00' * (length % 2))
-        return [string[i:i+2] for i in range(0, length, 2)]
+        return [string[i:i + 2] for i in range(0, length, 2)]
 
     def add_bits(self, values):
         """ Adds a collection of bits to be encoded
@@ -171,7 +172,7 @@ class BcdPayloadDecoder(object):
         :param endian: The endianess of the payload
         :returns: An initialized PayloadDecoder
         """
-        if isinstance(registers, list): # repack into flat binary
+        if isinstance(registers, list):  # repack into flat binary
             payload = ''.join(pack('>H', x) for x in registers)
             return BinaryPayloadDecoder(payload, endian)
         raise ParameterException('Invalid collection of registers supplied')

--- a/examples/contrib/concurrent_client.py
+++ b/examples/contrib/concurrent_client.py
@@ -47,8 +47,8 @@ class _Primitives(object):
     """
 
     def __init__(self, **kwargs):
-        self.queue  = kwargs.get('queue')
-        self.event  = kwargs.get('event')
+        self.queue = kwargs.get('queue')
+        self.event = kwargs.get('event')
         self.worker = kwargs.get('worker')
 
     @classmethod
@@ -78,8 +78,9 @@ class _Primitives(object):
 # We use named tuples here as they are very lightweight while giving us
 # all the benefits of classes.
 # -------------------------------------------------------------------------- #
-WorkRequest  = namedtuple('WorkRequest',  'request, work_id')
+WorkRequest  = namedtuple('WorkRequest',  'request, work_id') # noqa 241
 WorkResponse = namedtuple('WorkResponse', 'is_exception, work_id, response')
+
 
 # -------------------------------------------------------------------------- #
 # Define our worker processes
@@ -103,7 +104,8 @@ def _client_worker_process(factory, input_queue, output_queue, is_shutdown):
         try:
             workitem = input_queue.get(timeout=1)
             log.debug("dequeue worker request: %s", workitem)
-            if not workitem: continue
+            if not workitem:
+                continue
             try:
                 log.debug("executing request on thread: %s", workitem)
                 result = client.execute(workitem.request)
@@ -113,7 +115,7 @@ def _client_worker_process(factory, input_queue, output_queue, is_shutdown):
                               "thread: %s", threading.current_thread())
                 output_queue.put(WorkResponse(True,
                                               workitem.work_id, exception))
-        except Exception as ex:
+        except Exception:
             pass
     log.info("request worker shutting down: %s", threading.current_thread())
 
@@ -137,13 +139,15 @@ def _manager_worker_process(output_queue, futures, is_shutdown):
             workitem = output_queue.get()
             future = futures.get(workitem.work_id, None)
             log.debug("dequeue manager response: %s", workitem)
-            if not future: continue
+            if not future:
+                continue
             if workitem.is_exception:
                 future.set_exception(workitem.response)
-            else: future.set_result(workitem.response)
+            else:
+                future.set_result(workitem.response)
             log.debug("updated future result: %s", future)
             del futures[workitem.work_id]
-        except Exception as ex:
+        except Exception:
             log.exception("error in manager")
     log.info("manager worker shutting down: %s", threading.current_thread())
 
@@ -190,7 +194,7 @@ class ConcurrentClient(ModbusClientMixin):
             self.workers.append(worker)
 
     def shutdown(self):
-        """ Shutdown all the workers being used to 
+        """ Shutdown all the workers being used to
         concurrently process the requests.
         """
         log.info("stating to shut down workers")
@@ -233,7 +237,7 @@ if __name__ == "__main__":
         client.connect()
         return client
 
-    client = ConcurrentClient(factory = client_factory)
+    client = ConcurrentClient(factory=client_factory)
     try:
         log.info("issuing concurrent requests")
         futures = [client.read_coils(i * 8, 8) for i in range(10)]

--- a/examples/contrib/deviceinfo_showcase_server.py
+++ b/examples/contrib/deviceinfo_showcase_server.py
@@ -8,18 +8,18 @@ to clients about the device. This is part of the MODBUS specification, and
 uses the MEI 0x2B 0x0E request / response. This example creates an otherwise
 empty server.
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the various server implementations
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
 from pymodbus.server.sync import StartTcpServer
-from pymodbus.server.sync import StartUdpServer
-from pymodbus.server.sync import StartSerialServer
+# from pymodbus.server.sync import StartUdpServer
+# from pymodbus.server.sync import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 
-from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
+# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 
 # --------------------------------------------------------------------------- #
 # import versions of libraries which we will use later on for the example
@@ -27,9 +27,9 @@ from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 from pymodbus import __version__ as pymodbus_version
 from serial import __version__ as pyserial_version
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the service logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 import logging
 FORMAT = ('%(asctime)-15s %(threadName)-15s'
           ' %(levelname)-8s %(module)-15s:%(lineno)-8s %(message)s')
@@ -44,12 +44,12 @@ def run_server():
     # ----------------------------------------------------------------------- #
     store = ModbusSlaveContext()
     context = ModbusServerContext(slaves=store, single=True)
-    
-    # ----------------------------------------------------------------------- # 
+
+    # ----------------------------------------------------------------------- #
     # initialize the server information
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # If you don't set this or any fields, they are defaulted to empty strings.
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     identity = ModbusDeviceIdentification()
     identity.VendorName = 'Pymodbus'
     identity.ProductCode = 'PM'
@@ -90,7 +90,7 @@ def run_server():
 
     # ----------------------------------------------------------------------- #
     # run the server you want
-    # ----------------------------------------------------------------------- # 
+    # ----------------------------------------------------------------------- #
     # Tcp:
     StartTcpServer(context, identity=identity, address=("localhost", 5020))
 
@@ -100,11 +100,11 @@ def run_server():
 
     # Udp:
     # StartUdpServer(context, identity=identity, address=("0.0.0.0", 5020))
-    
+
     # Ascii:
     # StartSerialServer(context, identity=identity,
     #                    port='/dev/ttyp0', timeout=1)
-    
+
     # RTU:
     # StartSerialServer(context, framer=ModbusRtuFramer, identity=identity,
     #                   port='/dev/ttyp0', timeout=.005, baudrate=9600)

--- a/examples/contrib/deviceinfo_showcase_server.py
+++ b/examples/contrib/deviceinfo_showcase_server.py
@@ -13,13 +13,9 @@ empty server.
 # --------------------------------------------------------------------------- #
 from pymodbus.version import version
 from pymodbus.server.sync import StartTcpServer
-# from pymodbus.server.sync import StartUdpServer
-# from pymodbus.server.sync import StartSerialServer
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
-
-# from pymodbus.transaction import ModbusRtuFramer, ModbusBinaryFramer
 
 # --------------------------------------------------------------------------- #
 # import versions of libraries which we will use later on for the example

--- a/examples/contrib/libmodbus_client.py
+++ b/examples/contrib/libmodbus_client.py
@@ -72,7 +72,8 @@ compiler.cdef("""
     int modbus_write_bits(modbus_t *ctx, int addr, int nb, const uint8_t *data);
     int modbus_write_register(modbus_t *ctx, int reg_addr, int value);
     int modbus_write_registers(modbus_t *ctx, int addr, int nb, const uint16_t *data);
-    int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, int write_nb, const uint16_t *src, int read_addr, int read_nb, uint16_t *dest);
+    int modbus_write_and_read_registers(modbus_t *ctx, int write_addr, int write_nb,
+                                        const uint16_t *src, int read_addr, int read_nb, uint16_t *dest);
 
     int modbus_mask_write_register(modbus_t *ctx, int addr, uint16_t and_mask, uint16_t or_mask);
     int modbus_send_raw_request(modbus_t *ctx, uint8_t *raw_req, int raw_req_length);
@@ -88,7 +89,7 @@ compiler.cdef("""
     int modbus_receive_from(modbus_t *ctx, int sockfd, uint8_t *req);
     int modbus_receive_confirmation(modbus_t *ctx, uint8_t *rsp);
 """)
-LIB = compiler.dlopen('modbus') # create our bindings
+LIB = compiler.dlopen('modbus')  # create our bindings
 
 # -------------------------------------------------------------------------- #
 # helper utilites
@@ -147,9 +148,9 @@ class LibmodbusLevel1Client(object):
             :param baudrate: The baud rate to use for the serial device
             :returns: A new level1 client
         """
-        port     = kwargs.get('port', '/dev/ttyS0')
+        port     = kwargs.get('port', '/dev/ttyS0')  # noqa E221
         baudrate = kwargs.get('baud', Defaults.Baudrate)
-        parity   = kwargs.get('parity', Defaults.Parity)
+        parity   = kwargs.get('parity', Defaults.Parity) # noqa E221
         bytesize = kwargs.get('bytesize', Defaults.Bytesize)
         stopbits = kwargs.get('stopbits', Defaults.Stopbits)
         client = LIB.modbus_new_rtu(port, baudrate, parity, bytesize, stopbits)
@@ -166,7 +167,7 @@ class LibmodbusLevel1Client(object):
         :param client: The underlying client instance to operate with.
         """
         self.client = client
-        self.slave  = Defaults.UnitId
+        self.slave = Defaults.UnitId
 
     def set_slave(self, slave):
         """ Set the current slave to operate against.
@@ -310,8 +311,8 @@ class LibmodbusLevel1Client(object):
         write_count = len(write_registers)
         read_result = compiler.new("uint16_t[]", read_count)
         self.__execute(LIB.modbus_write_and_read_registers,
-            write_address, write_count, write_registers,
-            read_address, read_count, read_result)
+                       write_address, write_count, write_registers,
+                       read_address, read_count, read_result)
         return read_result
 
 # -------------------------------------------------------------------------- #
@@ -332,24 +333,24 @@ class LibmodbusClient(ModbusClientMixin):
 
     __methods = {
         'ReadCoilsRequest': lambda c, r: c.read_bits(r.address, r.count),
-        'ReadDiscreteInputsRequest': lambda c, r: c.read_input_bits(r.address, 
+        'ReadDiscreteInputsRequest': lambda c, r: c.read_input_bits(r.address,
                                                                     r.count),
-        'WriteSingleCoilRequest': lambda c, r: c.write_bit(r.address, 
+        'WriteSingleCoilRequest': lambda c, r: c.write_bit(r.address,
                                                            r.value),
-        'WriteMultipleCoilsRequest': lambda c, r: c.write_bits(r.address, 
+        'WriteMultipleCoilsRequest': lambda c, r: c.write_bits(r.address,
                                                                r.values),
-        'WriteSingleRegisterRequest': lambda c, r: c.write_register(r.address, 
+        'WriteSingleRegisterRequest': lambda c, r: c.write_register(r.address,
                                                                     r.value),
-        'WriteMultipleRegistersRequest': 
+        'WriteMultipleRegistersRequest':
             lambda c, r: c.write_registers(r.address, r.values),
-        'ReadHoldingRegistersRequest': 
+        'ReadHoldingRegistersRequest':
             lambda c, r: c.read_registers(r.address, r.count),
-        'ReadInputRegistersRequest': 
+        'ReadInputRegistersRequest':
             lambda c, r: c.read_input_registers(r.address, r.count),
-        'ReadWriteMultipleRegistersRequest': 
-            lambda c, r: c.read_and_write_registers(r.read_address, 
-                                                    r.read_count, 
-                                                    r.write_address, 
+        'ReadWriteMultipleRegistersRequest':
+            lambda c, r: c.read_and_write_registers(r.read_address,
+                                                    r.read_count,
+                                                    r.write_address,
                                                     r.write_registers),
     }
 
@@ -359,23 +360,23 @@ class LibmodbusClient(ModbusClientMixin):
     # ----------------------------------------------------------------------- #
 
     __adapters = {
-        'ReadCoilsRequest': 
+        'ReadCoilsRequest':
             lambda tx, rx: ReadCoilsResponse(list(rx)),
-        'ReadDiscreteInputsRequest': 
+        'ReadDiscreteInputsRequest':
             lambda tx, rx: ReadDiscreteInputsResponse(list(rx)),
-        'WriteSingleCoilRequest': 
+        'WriteSingleCoilRequest':
             lambda tx, rx: WriteSingleCoilResponse(tx.address, rx),
-        'WriteMultipleCoilsRequest': 
+        'WriteMultipleCoilsRequest':
             lambda tx, rx: WriteMultipleCoilsResponse(tx.address, rx),
-        'WriteSingleRegisterRequest': 
+        'WriteSingleRegisterRequest':
             lambda tx, rx: WriteSingleRegisterResponse(tx.address, rx),
-        'WriteMultipleRegistersRequest': 
+        'WriteMultipleRegistersRequest':
             lambda tx, rx: WriteMultipleRegistersResponse(tx.address, rx),
-        'ReadHoldingRegistersRequest': 
+        'ReadHoldingRegistersRequest':
             lambda tx, rx: ReadHoldingRegistersResponse(list(rx)),
-        'ReadInputRegistersRequest': 
+        'ReadInputRegistersRequest':
             lambda tx, rx: ReadInputRegistersResponse(list(rx)),
-        'ReadWriteMultipleRegistersRequest': 
+        'ReadWriteMultipleRegistersRequest':
             lambda tx, rx: ReadWriteMultipleRegistersResponse(list(rx)),
     }
 

--- a/examples/contrib/message_generator.py
+++ b/examples/contrib/message_generator.py
@@ -220,14 +220,14 @@ def main():
         try:
             modbus_log.setLevel(logging.DEBUG)
             logging.basicConfig()
-        except Exception as e:
+        except Exception:
             print("Logging is not supported on this system")
 
     framer = lookup = {
-        'tcp':    ModbusSocketFramer,
-        'rtu':    ModbusRtuFramer,
+        'tcp':    ModbusSocketFramer, # noqa E221
+        'rtu':    ModbusRtuFramer, # noqa E221
         'binary': ModbusBinaryFramer,
-        'ascii':  ModbusAsciiFramer,
+        'ascii':  ModbusAsciiFramer, # noqa E221
     }.get(option.framer, ModbusSocketFramer)(None)
 
     generate_messages(framer, option)

--- a/examples/contrib/message_parser.py
+++ b/examples/contrib/message_parser.py
@@ -54,17 +54,25 @@ class Decoder(object):
 
         :param message: The message to decode
         """
+<<<<<<< HEAD
         value = message if self.encode else c.encode(message, 'hex_codec')
         print("="*80)
+=======
+        if IS_PYTHON3:
+            value = message if self.encode else c.encode(message, 'hex_codec')
+        else:
+            value = message if self.encode else message.encode('hex')
+        print("=" * 80)
+>>>>>>> 12f99ef9f (lint /examples per PEP8)
         print("Decoding Message %s" % value)
-        print("="*80)
+        print("=" * 80)
         decoders = [
             self.framer(ServerDecoder(), client=None),
             self.framer(ClientDecoder(), client=None)
         ]
         for decoder in decoders:
             print("%s" % decoder.decoder.__class__.__name__)
-            print("-"*80)
+            print("-" * 80)
             try:
                 decoder.addToFrame(message)
                 if decoder.checkFrame():
@@ -73,7 +81,7 @@ class Decoder(object):
                     decoder.processIncomingPacket(message, self.report, unit)
                 else:
                     self.check_errors(decoder, message)
-            except Exception as ex:
+            except Exception:
                 self.check_errors(decoder, message)
 
     def check_errors(self, decoder, message):
@@ -93,12 +101,12 @@ class Decoder(object):
         for (k, v) in message.__dict__.items():
             if isinstance(v, dict):
                 print("%-15s =" % k)
-                for kk,vv in v.items():
+                for kk, vv in v.items():
                     print("  %-12s => %s" % (kk, vv))
 
             elif isinstance(v, collections.Iterable):
                 print("%-15s =" % k)
-                value = str([int(x) for x  in v])
+                value = str([int(x) for x in v])
                 for line in textwrap.wrap(value, 60):
                     print("%-15s . %s" % ("", line))
             else:
@@ -177,7 +185,8 @@ def get_messages(option):
     elif option.file:
         with open(option.file, "r") as handle:
             for line in handle:
-                if line.startswith('#'): continue
+                if line.startswith('#'):
+                    continue
                 if not option.ascii:
                     line = line.strip()
                     line = line.decode('hex')
@@ -197,10 +206,10 @@ def main():
             print("Logging is not supported on this system- {}".format(e))
 
     framer = lookup = {
-        'tcp':    ModbusSocketFramer,
-        'rtu':    ModbusRtuFramer,
+        'tcp':    ModbusSocketFramer,  # noqa E221
+        'rtu':    ModbusRtuFramer,  # noqa E221
         'binary': ModbusBinaryFramer,
-        'ascii':  ModbusAsciiFramer,
+        'ascii':  ModbusAsciiFramer,  # noqa E221
     }.get(option.framer or option.parser, ModbusSocketFramer)
 
     decoder = Decoder(framer, option.ascii)

--- a/examples/contrib/modbus_mapper.py
+++ b/examples/contrib/modbus_mapper.py
@@ -23,7 +23,7 @@ requested functionality)::
     template = ['address', 'size', 'function', 'name', 'description']
     raw_mapping = csv_mapping_parser('input.csv', template)
     mapping = mapping_decoder(raw_mapping)
-    
+
     index, size = 1, 100
     client = ModbusTcpClient('localhost')
     response = client.read_holding_registers(index, size)
@@ -56,9 +56,9 @@ from pymodbus.datastore.context import ModbusSlaveContext
 from io import StringIO
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # raw mapping input parsers
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # These generate the raw mapping_blocks from some form of input
 # which can then be passed to the decoder in question to supply
 # the requested output result.
@@ -85,7 +85,7 @@ def csv_mapping_parser(path, template):
     mapping_blocks = defaultdict(dict)
     with open(path, 'r') as handle:
         reader = csv.reader(handle)
-        reader.next() # skip the csv header
+        reader.next()  # skip the csv header
         for row in reader:
             mapping = dict(zip(template, row))
             fid = mapping.pop('function')
@@ -121,7 +121,7 @@ def json_mapping_parser(path, template):
         for tid, rows in json.load(handle).iteritems():
             mappings = {}
             for key, values in rows.iteritems():
-                mapping = {template.get(k, k) : v for k, v in values.iteritems()}
+                mapping = {template.get(k, k): v for k, v in values.iteritems()}
                 mappings[int(key)] = mapping
             mapping_blocks[tid] = mappings
     return mapping_blocks
@@ -141,12 +141,12 @@ def xml_mapping_parser(path):
     pass
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # modbus context decoders
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # These are used to decode a raw mapping_block into a slave context with
 # populated function data blocks.
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 def modbus_context_decoder(mapping_blocks):
     """ Given a mapping block input, generate a backing
     slave context with initialized data blocks.
@@ -162,20 +162,20 @@ def modbus_context_decoder(mapping_blocks):
     blocks = defaultdict(dict)
     for block in mapping_blocks.itervalues():
         for mapping in block.itervalues():
-            value    = int(mapping['value'])
-            address  = int(mapping['address'])
+            value = int(mapping['value'])
+            address = int(mapping['address'])
             function = mapping['function']
             blocks[function][address] = value
     return ModbusSlaveContext(**blocks)
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # modbus mapping decoder
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # These are used to decode a raw mapping_block into a request decoder.
 # So this allows one to simply grab a number of registers, and then
 # pass them to this decoder which will do the rest.
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class ModbusTypeDecoder(object):
     """ This is a utility to determine the correct
     decoder to use given a type name. By default this
@@ -197,21 +197,21 @@ class ModbusTypeDecoder(object):
         """
         self.default = lambda m: self.parse_16bit_uint
         self.parsers = {
-            'uint':    self.parse_16bit_uint,
-            'uint8':   self.parse_8bit_uint,
-            'uint16':  self.parse_16bit_uint,
-            'uint32':  self.parse_32bit_uint,
-            'uint64':  self.parse_64bit_uint,
-            'int':     self.parse_16bit_int,
-            'int8':    self.parse_8bit_int,
-            'int16':   self.parse_16bit_int,
-            'int32':   self.parse_32bit_int,
-            'int64':   self.parse_64bit_int,
-            'float':   self.parse_32bit_float,
-            'float32': self.parse_32bit_float,
-            'float64': self.parse_64bit_float,
-            'string':  self.parse_32bit_int,
-            'bits':    self.parse_bits,
+            'uint':    self.parse_16bit_uint,  # noqa E221
+            'uint8':   self.parse_8bit_uint,  # noqa E221
+            'uint16':  self.parse_16bit_uint,  # noqa E221
+            'uint32':  self.parse_32bit_uint,  # noqa E221
+            'uint64':  self.parse_64bit_uint,  # noqa E221
+            'int':     self.parse_16bit_int,  # noqa E221
+            'int8':    self.parse_8bit_int,  # noqa E221
+            'int16':   self.parse_16bit_int,  # noqa E221
+            'int32':   self.parse_32bit_int,  # noqa E221
+            'int64':   self.parse_64bit_int,  # noqa E221
+            'float':   self.parse_32bit_float,  # noqa E221
+            'float32': self.parse_32bit_float,  # noqa E221
+            'float64': self.parse_64bit_float,  # noqa E221
+            'string':  self.parse_32bit_int,  # noqa E221
+            'bits':    self.parse_bits,  # noqa E221
         }
 
     # ------------------------------------------------------------ #
@@ -267,12 +267,12 @@ class ModbusTypeDecoder(object):
     def parse_64bit_float(tokens):
         return lambda d: d.decode_64bit_float()
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     # Public Interface
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     def tokenize(self, value):
         """ Given a value, return the tokens
-    
+
         :param value: The value to tokenize
         :returns: A token generator
         """
@@ -289,7 +289,7 @@ class ModbusTypeDecoder(object):
         :returns: The decoder method to use
         """
         tokens = self.tokenize(value)
-        token  = tokens.next().lower()
+        token = tokens.next().lower()
         parser = self.parsers.get(token, self.default)
         return parser(tokens)
 

--- a/examples/contrib/modbus_saver.py
+++ b/examples/contrib/modbus_saver.py
@@ -63,9 +63,9 @@ class ModbusDatastoreSaver(object):
                 self.handle_slave_end(slave_name)
             self.handle_save_end()
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     # predefined state machine callbacks
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     def handle_save_start(self):
         pass
 
@@ -163,10 +163,10 @@ class XmlDatastoreSaver(ModbusDatastoreSaver):
     _store = None
 
     STORE_NAMES = {
-        'i' : 'input-registers',
-        'd' : 'discretes',
-        'h' : 'holding-registers',
-        'c' : 'coils',
+        'i': 'input-registers',
+        'd': 'discretes',
+        'h': 'holding-registers',
+        'c': 'coils',
     }
 
     def handle_save_start(self):

--- a/examples/contrib/modbus_scraper.py
+++ b/examples/contrib/modbus_scraper.py
@@ -19,24 +19,24 @@ from pymodbus.client.asynchronous.twisted import ModbusClientProtocol
 import logging
 log = logging.getLogger("pymodbus")
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Choose the framer you want to use
-# --------------------------------------------------------------------------- # 
-from pymodbus.transaction import ModbusBinaryFramer
-from pymodbus.transaction import ModbusAsciiFramer
-from pymodbus.transaction import ModbusRtuFramer
-from pymodbus.transaction import ModbusSocketFramer
+# --------------------------------------------------------------------------- #
+# from pymodbus.transaction import ModbusBinaryFramer
+# from pymodbus.transaction import ModbusAsciiFramer
+# from pymodbus.transaction import ModbusRtuFramer
+# from pymodbus.transaction import ModbusSocketFramer
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Define some constants
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 COUNT = 8    # The number of bits/registers to read at once
 DELAY = 0    # The delay between subsequent reads
 SLAVE = 0x01  # The slave unit id to read from
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # A simple scraper protocol
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # I tried to spread the load across the device, but feel free to modify the
 # logic to suit your own purpose.
 # --------------------------------------------------------------------------- #
@@ -61,7 +61,7 @@ class ScraperProtocol(ModbusClientProtocol):
         """
         super(ScraperProtocol, self).connectionMade()
         log.debug("Beginning the processing loop")
-        self.address  = self.factory.starting
+        self.address = self.factory.starting
         reactor.callLater(DELAY, self.scrape_holding_registers)
 
     def connectionLost(self, reason):
@@ -127,9 +127,9 @@ class ScraperProtocol(ModbusClientProtocol):
         log.error(failure)
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # a factory for the example protocol
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # This is used to build client protocol's if you tie into twisted's method
 # of processing. It basically produces client instances of the underlying
 # protocol::
@@ -137,14 +137,14 @@ class ScraperProtocol(ModbusClientProtocol):
 #     Factory(Protocol) -> ProtocolInstance
 #
 # It also persists data between client instances (think protocol singelton).
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class ScraperFactory(ClientFactory):
 
     protocol = ScraperProtocol
 
     def __init__(self, framer, endpoint, query):
         """ Remember things necessary for building a protocols """
-        self.framer   = framer
+        self.framer = framer
         self.endpoint = endpoint
         self.starting, self.ending = query
 
@@ -155,16 +155,16 @@ class ScraperFactory(ClientFactory):
         return protocol
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # a custom client for our device
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Twisted provides a number of helper methods for creating and starting
 # clients:
 # - protocol.ClientCreator
 # - reactor.connectTCP
 #
 # How you start your client is really up to you.
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class SerialModbusClient(serialport.SerialPort):
 
     def __init__(self, factory, *args, **kwargs):
@@ -177,14 +177,14 @@ class SerialModbusClient(serialport.SerialPort):
         serialport.SerialPort.__init__(self, protocol, *args, **kwargs)
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # a custom endpoint for our results
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # An example line reader, this can replace with:
 # - the TCP protocol
 # - a context recorder
 # - a database or file recorder
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class LoggingContextReader(object):
 
     def __init__(self, output):
@@ -192,12 +192,12 @@ class LoggingContextReader(object):
 
         :param output: The output file to save to
         """
-        self.output  = output
+        self.output = output
         self.context = ModbusSlaveContext(
-            di = ModbusSequentialDataBlock.create(),
-            co = ModbusSequentialDataBlock.create(),
-            hr = ModbusSequentialDataBlock.create(),
-            ir = ModbusSequentialDataBlock.create())
+            di=ModbusSequentialDataBlock.create(),
+            co=ModbusSequentialDataBlock.create(),
+            hr=ModbusSequentialDataBlock.create(),
+            ir=ModbusSequentialDataBlock.create())
 
     def write(self, response):
         """ Handle the next modbus response
@@ -224,30 +224,30 @@ def get_options():
     parser = OptionParser()
 
     parser.add_option("-o", "--output",
-        help="The resulting output file for the scrape",
-        dest="output", default="datastore.pickle")
+                      help="The resulting output file for the scrape",
+                      dest="output", default="datastore.pickle")
 
     parser.add_option("-p", "--port",
-        help="The port to connect to", type='int',
-        dest="port", default=502)
+                      help="The port to connect to", type='int',
+                      dest="port", default=502)
 
     parser.add_option("-s", "--server",
-        help="The server to scrape",
-        dest="host", default="127.0.0.1")
+                      help="The server to scrape",
+                      dest="host", default="127.0.0.1")
 
     parser.add_option("-r", "--range",
-        help="The address range to scan",
-        dest="query", default="0:1000")
+                      help="The address range to scan",
+                      dest="query", default="0:1000")
 
     parser.add_option("-d", "--debug",
-        help="Enable debug tracing",
-        action="store_true", dest="debug", default=False)
+                      help="Enable debug tracing",
+                      action="store_true", dest="debug", default=False)
 
     (opt, arg) = parser.parse_args()
     return opt
 
 
-def main():    
+def main():
     """ The main runner function """
     options = get_options()
 
@@ -255,7 +255,7 @@ def main():
         try:
             log.setLevel(logging.DEBUG)
             logging.basicConfig()
-        except Exception as ex:
+        except Exception:
             print("Logging is not supported on this system")
 
     # split the query into a starting and ending range
@@ -263,8 +263,8 @@ def main():
 
     try:
         log.debug("Initializing the client")
-        framer  = ModbusSocketFramer(ClientDecoder())
-        reader  = LoggingContextReader(options.output)
+        framer = ModbusSocketFramer(ClientDecoder())
+        reader = LoggingContextReader(options.output)
         factory = ScraperFactory(framer, reader, query)
 
         # how to connect based on TCP vs Serial clients

--- a/examples/contrib/modbus_simulator.py
+++ b/examples/contrib/modbus_simulator.py
@@ -6,10 +6,9 @@ with read/write data as well as user configurable base data
 
 import pickle
 from optparse import OptionParser
-from twisted.internet import reactor
 
 from pymodbus.server.asynchronous import StartTcpServer
-from pymodbus.datastore import ModbusServerContext,ModbusSlaveContext
+from pymodbus.datastore import ModbusServerContext, ModbusSlaveContext
 
 # -------------------------------------------------------------------------- #
 # Logging
@@ -25,13 +24,13 @@ protocol_log = logging.getLogger("pymodbus.protocol")
 # -------------------------------------------------------------------------- #
 # These are extra helper functions that don't belong in a class
 # -------------------------------------------------------------------------- #
-import getpass
+# import getpass
 
 
 def root_test():
     """ Simple test to see if we are running as root """
     return True  # removed for the time being as it isn't portable
-    #return getpass.getuser() == "root"
+    # return getpass.getuser() == "root"
 
 # -------------------------------------------------------------------------- #
 # Helper Classes
@@ -55,7 +54,6 @@ class ConfigurationException(Exception):
         :returns: A string representation of the object
         """
         return 'Configuration Error: %s' % self.string
-
 
 
 class Configuration:
@@ -116,7 +114,7 @@ def main():
         try:
             server_log.setLevel(logging.DEBUG)
             protocol_log.setLevel(logging.DEBUG)
-        except Exception as e:
+        except Exception:
             print("Logging is not supported on this system")
 
     # parse configuration file and run

--- a/examples/contrib/modicon_payload.py
+++ b/examples/contrib/modicon_payload.py
@@ -3,7 +3,7 @@ Modbus Modicon Payload Builder
 -----------------------------------------------------------
 
 This is an example of building a custom payload builder
-that can be used in the pymodbus library. Below is a 
+that can be used in the pymodbus library. Below is a
 simple modicon encoded builder and decoder.
 """
 from struct import pack, unpack
@@ -58,7 +58,7 @@ class ModiconPayloadBuilder(IPayloadBuilder):
         string = str(self)
         length = len(string)
         string = string + ('\x00' * (length % 2))
-        return [string[i:i+2] for i in range(0, length, 2)]
+        return [string[i:i + 2] for i in range(0, length, 2)]
 
     def add_bits(self, values):
         """ Adds a collection of bits to be encoded
@@ -178,7 +178,7 @@ class ModiconPayloadDecoder(object):
         :param endian: The endianess of the payload
         :returns: An initialized PayloadDecoder
         """
-        if isinstance(registers, list): # repack into flat binary
+        if isinstance(registers, list):  # repack into flat binary
             payload = ''.join(pack('>H', x) for x in registers)
             return ModiconPayloadDecoder(payload, endian)
         raise ParameterException('Invalid collection of registers supplied')

--- a/examples/contrib/serial_forwarder.py
+++ b/examples/contrib/serial_forwarder.py
@@ -7,18 +7,19 @@ We basically set the context for the tcp serial server to be that of a
 serial client! This is just an example of how clever you can be with
 the data context (basically anything can become a modbus device).
 """
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # import the various server implementations
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 from pymodbus.server.sync import StartTcpServer as StartServer
 from pymodbus.client.sync import ModbusSerialClient as ModbusClient
 
 from pymodbus.datastore.remote import RemoteSlaveContext
-from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
+from pymodbus.datastore import ModbusServerContext
+# from pymodbus.datastore import ModbusSlaveContext
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # configure the service logging
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 import logging
 logging.basicConfig()
 log = logging.getLogger()

--- a/examples/contrib/serial_forwarder.py
+++ b/examples/contrib/serial_forwarder.py
@@ -15,7 +15,6 @@ from pymodbus.client.sync import ModbusSerialClient as ModbusClient
 
 from pymodbus.datastore.remote import RemoteSlaveContext
 from pymodbus.datastore import ModbusServerContext
-# from pymodbus.datastore import ModbusSlaveContext
 
 # --------------------------------------------------------------------------- #
 # configure the service logging

--- a/examples/contrib/sunspec_client.py
+++ b/examples/contrib/sunspec_client.py
@@ -13,33 +13,33 @@ _logger.setLevel(logging.DEBUG)
 logging.basicConfig()
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Sunspec Common Constants
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class SunspecDefaultValue(object):
     """ A collection of constants to indicate if
     a value is not implemented.
     """
-    Signed16        = 0x8000
-    Unsigned16      = 0xffff
-    Accumulator16   = 0x0000
-    Scale           = 0x8000
-    Signed32        = 0x80000000
-    Float32         = 0x7fc00000
-    Unsigned32      = 0xffffffff
-    Accumulator32   = 0x00000000
-    Signed64        = 0x8000000000000000
-    Unsigned64      = 0xffffffffffffffff
-    Accumulator64   = 0x0000000000000000
-    String          = '\x00'
+    Signed16        = 0x8000  # noqa E221
+    Unsigned16      = 0xffff  # noqa E221
+    Accumulator16   = 0x0000  # noqa E221
+    Scale           = 0x8000  # noqa E221
+    Signed32        = 0x80000000  # noqa E221
+    Float32         = 0x7fc00000  # noqa E221
+    Unsigned32      = 0xffffffff  # noqa E221
+    Accumulator32   = 0x00000000  # noqa E221
+    Signed64        = 0x8000000000000000  # noqa E221
+    Unsigned64      = 0xffffffffffffffff  # noqa E221
+    Accumulator64   = 0x0000000000000000  # noqa E221
+    String          = '\x00'  # noqa E221
 
 
 class SunspecStatus(object):
     """ Indicators of the current status of a
     sunspec device
     """
-    Normal  = 0x00000000
-    Error   = 0xfffffffe
+    Normal  = 0x00000000  # noqa E221
+    Error   = 0xfffffffe  # noqa E221
     Unknown = 0xffffffff
 
 
@@ -54,73 +54,73 @@ class SunspecModel(object):
     """ Assigned device indentifiers that are pre-assigned
     by the sunspec protocol.
     """
-    #---------------------------------------------
+    # ---------------------------------------------
     # 0xx Common Models
-    #---------------------------------------------
-    CommonBlock                              = 1
-    AggregatorBlock                          = 2
+    # ---------------------------------------------
+    CommonBlock                              = 1  # noqa E221
+    AggregatorBlock                          = 2  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 1xx Inverter Models
-    #---------------------------------------------
-    SinglePhaseIntegerInverter               = 101
-    SplitPhaseIntegerInverter                = 102
-    ThreePhaseIntegerInverter                = 103
-    SinglePhaseFloatsInverter                = 103
-    SplitPhaseFloatsInverter                 = 102
-    ThreePhaseFloatsInverter                 = 103
+    # ---------------------------------------------
+    SinglePhaseIntegerInverter               = 101  # noqa E221
+    SplitPhaseIntegerInverter                = 102  # noqa E221
+    ThreePhaseIntegerInverter                = 103  # noqa E221
+    SinglePhaseFloatsInverter                = 103  # noqa E221
+    SplitPhaseFloatsInverter                 = 102  # noqa E221
+    ThreePhaseFloatsInverter                 = 103  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 2xx Meter Models
-    #---------------------------------------------
-    SinglePhaseMeter                         = 201
-    SplitPhaseMeter                          = 201
-    WyeConnectMeter                          = 201
-    DeltaConnectMeter                        = 201
+    # ---------------------------------------------
+    SinglePhaseMeter                         = 201  # noqa E221
+    SplitPhaseMeter                          = 201  # noqa E221
+    WyeConnectMeter                          = 201  # noqa E221
+    DeltaConnectMeter                        = 201  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 3xx Environmental Models
-    #---------------------------------------------
-    BaseMeteorological                       = 301
-    Irradiance                               = 302
-    BackOfModuleTemperature                  = 303
-    Inclinometer                             = 304
-    Location                                 = 305
-    ReferencePoint                           = 306
-    BaseMeteorological                       = 307
-    MiniMeteorological                       = 308
+    # ---------------------------------------------
+    BaseMeteorological                       = 301  # noqa E221
+    Irradiance                               = 302  # noqa E221
+    BackOfModuleTemperature                  = 303  # noqa E221
+    Inclinometer                             = 304  # noqa E221
+    Location                                 = 305  # noqa E221
+    ReferencePoint                           = 306  # noqa E221
+    BaseMeteorological                       = 307  # noqa E221
+    MiniMeteorological                       = 308  # noqa E221
 
-    #---------------------------------------------
-    # 4xx String Combiner Models             
-    #---------------------------------------------
-    BasicStringCombiner                      = 401
-    AdvancedStringCombiner                   = 402
+    # ---------------------------------------------
+    # 4xx String Combiner Models
+    # ---------------------------------------------
+    BasicStringCombiner                      = 401  # noqa E221
+    AdvancedStringCombiner                   = 402  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 5xx Panel Models
-    #---------------------------------------------
-    PanelFloat                               = 501
-    PanelInteger                             = 502
+    # ---------------------------------------------
+    PanelFloat                               = 501  # noqa E221
+    PanelInteger                             = 502  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 641xx Outback Blocks
-    #---------------------------------------------
-    OutbackDeviceIdentifier                  = 64110
-    OutbackChargeController                  = 64111
-    OutbackFMSeriesChargeController          = 64112
-    OutbackFXInverterRealTime                = 64113
-    OutbackFXInverterConfiguration           = 64114
-    OutbackSplitPhaseRadianInverter          = 64115
-    OutbackRadianInverterConfiguration       = 64116
-    OutbackSinglePhaseRadianInverterRealTime = 64117
-    OutbackFLEXNetDCRealTime                 = 64118
-    OutbackFLEXNetDCConfiguration            = 64119
-    OutbackSystemControl                     = 64120
+    # ---------------------------------------------
+    OutbackDeviceIdentifier                  = 64110  # noqa E221
+    OutbackChargeController                  = 64111  # noqa E221
+    OutbackFMSeriesChargeController          = 64112  # noqa E221
+    OutbackFXInverterRealTime                = 64113  # noqa E221
+    OutbackFXInverterConfiguration           = 64114  # noqa E221
+    OutbackSplitPhaseRadianInverter          = 64115  # noqa E221
+    OutbackRadianInverterConfiguration       = 64116  # noqa E221
+    OutbackSinglePhaseRadianInverterRealTime = 64117  # noqa E221
+    OutbackFLEXNetDCRealTime                 = 64118  # noqa E221
+    OutbackFLEXNetDCConfiguration            = 64119  # noqa E221
+    OutbackSystemControl                     = 64120  # noqa E221
 
-    #---------------------------------------------
+    # ---------------------------------------------
     # 64xxx Vender Extension Block
-    #---------------------------------------------
-    EndOfSunSpecMap                          = 65535
+    # ---------------------------------------------
+    EndOfSunSpecMap                          = 65535  # noqa E221
 
     @classmethod
     def lookup(klass, code):
@@ -131,7 +131,7 @@ class SunspecModel(object):
         :returns: The device model name, or None if none available
         """
         values = dict((v, k) for k, v in klass.__dict__.iteritems()
-            if not callable(v))
+                      if not callable(v))
         return values.get(code, None)
 
 
@@ -139,14 +139,14 @@ class SunspecOffsets(object):
     """ Well known offsets that are used throughout
     the sunspec protocol
     """
-    CommonBlock             = 40000
-    CommonBlockLength       = 69
-    AlternateCommonBlock    = 50000
+    CommonBlock             = 40000  # noqa E221
+    CommonBlockLength       = 69  # noqa E221
+    AlternateCommonBlock    = 50000  # noqa E221
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Common Functions
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 def defer_or_apply(func):
     """ Decorator to apply an adapter method
     to a result regardless if it is a deferred
@@ -177,9 +177,9 @@ def create_sunspec_sync_client(host):
     return client
 
 
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 # Sunspec Client
-# --------------------------------------------------------------------------- # 
+# --------------------------------------------------------------------------- #
 class SunspecDecoder(BinaryPayloadDecoder):
     """ A decoder that deals correctly with the sunspec
     binary format.
@@ -219,11 +219,11 @@ class SunspecClient(object):
 
         :returns: True if successful, false otherwise
         """
-        decoder  = self.get_device_block(self.offset, 2)
+        decoder = self.get_device_block(self.offset, 2)
         if decoder.decode_32bit_uint() == SunspecIdentifier.Sunspec:
             return True
         self.offset = SunspecOffsets.AlternateCommonBlock
-        decoder  = self.get_device_block(self.offset, 2)
+        decoder = self.get_device_block(self.offset, 2)
         return decoder.decode_32bit_uint() == SunspecIdentifier.Sunspec
 
     def get_common_block(self):
@@ -232,20 +232,20 @@ class SunspecClient(object):
 
         :returns: A dictionary of the common block information
         """
-        length  = SunspecOffsets.CommonBlockLength
+        length = SunspecOffsets.CommonBlockLength
         decoder = self.get_device_block(self.offset, length)
         return {
-            'SunSpec_ID':       decoder.decode_32bit_uint(),
-            'SunSpec_DID':      decoder.decode_16bit_uint(),
-            'SunSpec_Length':   decoder.decode_16bit_uint(),
-            'Manufacturer':     decoder.decode_string(size=32),
-            'Model':            decoder.decode_string(size=32),
-            'Options':          decoder.decode_string(size=16),
-            'Version':          decoder.decode_string(size=16),
-            'SerialNumber':     decoder.decode_string(size=32),
-            'DeviceAddress':    decoder.decode_16bit_uint(),
-            'Next_DID':         decoder.decode_16bit_uint(),
-            'Next_DID_Length':  decoder.decode_16bit_uint(),
+            'SunSpec_ID':       decoder.decode_32bit_uint(),  # noqa E221
+            'SunSpec_DID':      decoder.decode_16bit_uint(),  # noqa E221
+            'SunSpec_Length':   decoder.decode_16bit_uint(),  # noqa E221
+            'Manufacturer':     decoder.decode_string(size=32),  # noqa E221
+            'Model':            decoder.decode_string(size=32),  # noqa E221
+            'Options':          decoder.decode_string(size=16),  # noqa E221
+            'Version':          decoder.decode_string(size=16),  # noqa E221
+            'SerialNumber':     decoder.decode_string(size=32),  # noqa E221
+            'DeviceAddress':    decoder.decode_16bit_uint(),  # noqa E221
+            'Next_DID':         decoder.decode_16bit_uint(),  # noqa E221
+            'Next_DID_Length':  decoder.decode_16bit_uint(),  # noqa E221
         }
 
     def get_device_block(self, offset, size):
@@ -276,14 +276,14 @@ class SunspecClient(object):
         """
         blocks = []
         offset = self.offset + 2
-        model  = SunspecModel.CommonBlock
+        model = SunspecModel.CommonBlock
         while model != SunspecModel.EndOfSunSpecMap:
             decoder = self.get_device_block(offset, 2)
-            model   = decoder.decode_16bit_uint()
-            length  = decoder.decode_16bit_uint()
+            model = decoder.decode_16bit_uint()
+            length = decoder.decode_16bit_uint()
             blocks.append({
-                'model' : model,
-                'name'  : SunspecModel.lookup(model),
+                'model': model,
+                'name': SunspecModel.lookup(model),
                 'length': length,
                 'offset': offset + length + 2
             })
@@ -291,9 +291,9 @@ class SunspecClient(object):
         return blocks
 
 
-#------------------------------------------------------------
+# ------------------------------------------------------------
 # A quick test runner
-#------------------------------------------------------------
+# ------------------------------------------------------------
 if __name__ == "__main__":
     client = create_sunspec_sync_client("YOUR.HOST.GOES.HERE")
 

--- a/examples/contrib/thread_safe_datastore.py
+++ b/examples/contrib/thread_safe_datastore.py
@@ -18,11 +18,13 @@ class ContextWrapper(object):
         self._factory = factory
 
     def __enter__(self):
-        if self.enter: self._enter()
+        if self.enter:
+            self._enter()
         return self if not self._factory else self._factory()
 
     def __exit__(self, args):
-        if self._leave: self._leave()
+        if self._leave:
+            self._leave()
 
 
 class ReadWriteLock(object):
@@ -41,43 +43,43 @@ class ReadWriteLock(object):
     def __init__(self):
         """ Initializes a new instance of the ReadWriteLock
         """
-        self.queue   = []     # the current writer queue
-        self.lock    = threading.Lock()   # the underlying condition lock
-        self.read_condition = threading.Condition(self.lock) # the single reader condition
+        self.queue = []     # the current writer queue
+        self.lock = threading.Lock()   # the underlying condition lock
+        self.read_condition = threading.Condition(self.lock)  # the single reader condition
         self.readers = 0                       # the number of current readers
-        self.writer  = False                   # is there a current writer
+        self.writer = False                   # is there a current writer
 
     def __is_pending_writer(self):
         return (self.writer                     # if there is a current writer
-            or (self.queue                    # or if there is a waiting writer
-           and (self.queue[0] != self.read_condition)))    # or if the queue head is not a reader
+                or (self.queue                    # or if there is a waiting writer
+                    and (self.queue[0] != self.read_condition)))    # or if the queue head is not a reader
 
     def acquire_reader(self):
         """ Notifies the lock that a new reader is requesting
         the underlying resource.
         """
         with self.lock:
-            if self.__is_pending_writer():                 # if there are existing writers waiting
-                if self.read_condition not in self.queue:  # do not pollute the queue with readers
-                    self.queue.append(self.read_condition) # add the readers in line for the queue
-                while self.__is_pending_writer():          # until the current writer is finished
-                    self.read_condition.wait(1)            # wait on our condition
-                if self.queue and self.read_condition == self.queue[0]: # if the read condition is at the queue head
-                    self.queue.pop(0)                      # then go ahead and remove it
-            self.readers += 1                              # update the current number of readers
+            if self.__is_pending_writer():                  # if there are existing writers waiting
+                if self.read_condition not in self.queue:   # do not pollute the queue with readers
+                    self.queue.append(self.read_condition)  # add the readers in line for the queue
+                while self.__is_pending_writer():           # until the current writer is finished
+                    self.read_condition.wait(1)             # wait on our condition
+                if self.queue and self.read_condition == self.queue[0]:  # if the read condition is at the queue head
+                    self.queue.pop(0)                       # then go ahead and remove it
+            self.readers += 1                               # update the current number of readers
 
     def acquire_writer(self):
         """ Notifies the lock that a new writer is requesting
         the underlying resource.
         """
         with self.lock:
-            if self.writer or self.readers:                # if we need to wait on a writer or readers
-                condition = threading.Condition(self.lock) # create a condition just for this writer
-                self.queue.append(condition)               # and put it on the waiting queue
-                while self.writer or self.readers:         # until the write lock is free
-                    condition.wait(1)                      # wait on our condition
-                self.queue.pop(0)                          # remove our condition after our condition is met
-            self.writer = True                             # stop other writers from operating
+            if self.writer or self.readers:                 # if we need to wait on a writer or readers
+                condition = threading.Condition(self.lock)  # create a condition just for this writer
+                self.queue.append(condition)                # and put it on the waiting queue
+                while self.writer or self.readers:          # until the write lock is free
+                    condition.wait(1)                       # wait on our condition
+                self.queue.pop(0)                           # remove our condition after our condition is met
+            self.writer = True                              # stop other writers from operating
 
     def release_reader(self):
         """ Notifies the lock that an existing reader is
@@ -96,7 +98,8 @@ class ReadWriteLock(object):
             self.writer = False                            # give up current writing handle
             if self.queue:                                 # if someone is waiting in the queue
                 self.queue[0].notify_all()                 # wake them up first
-            else: self.read_condition.notify_all()         # otherwise wake up all possible readers
+            else:
+                self.read_condition.notify_all()           # otherwise wake up all possible readers
 
     @contextmanager
     def get_reader_lock(self):
@@ -109,7 +112,8 @@ class ReadWriteLock(object):
         try:
             self.acquire_reader()
             yield self
-        finally: self.release_reader()
+        finally:
+            self.release_reader()
 
     @contextmanager
     def get_writer_lock(self):
@@ -122,7 +126,8 @@ class ReadWriteLock(object):
         try:
             self.acquire_writer()
             yield self
-        finally: self.release_writer()
+        finally:
+            self.release_writer()
 
 
 class ThreadSafeDataBlock(BaseModbusDataBlock):
@@ -131,7 +136,7 @@ class ThreadSafeDataBlock(BaseModbusDataBlock):
     safely operated on from multiple cocurrent threads.
 
     It should be noted that the choice was made to lock around the
-    datablock instead of the manager as there is less source of 
+    datablock instead of the manager as there is less source of
     contention (writes can occur to slave 0x01 while reads can
     occur to slave 0x02).
     """
@@ -142,7 +147,7 @@ class ThreadSafeDataBlock(BaseModbusDataBlock):
         :param block: The block to decorate
         """
         self.rwlock = ReadWriteLock()
-        self.block  = block
+        self.block = block
 
     def validate(self, address, count=1):
         """ Checks to see if the request is in range
@@ -163,7 +168,7 @@ class ThreadSafeDataBlock(BaseModbusDataBlock):
         """
         with self.rwlock.get_reader_lock():
             return self.block.getValues(address, count)
- 
+
     def setValues(self, address, values):
         """ Sets the requested values of the datastore
 
@@ -179,8 +184,8 @@ if __name__ == "__main__":
     class AtomicCounter(object):
         def __init__(self, **kwargs):
             self.counter = kwargs.get('start', 0)
-            self.finish  = kwargs.get('finish', 1000)
-            self.lock    = threading.Lock()
+            self.finish = kwargs.get('finish', 1000)
+            self.lock = threading.Lock()
 
         def increment(self, count=1):
             with self.lock:
@@ -202,8 +207,10 @@ if __name__ == "__main__":
             with locker.get_writer_lock():
                 writers.increment()
 
-    rthreads = [threading.Thread(target=read)  for i in range(50)]
+    rthreads = [threading.Thread(target=read) for i in range(50)]
     wthreads = [threading.Thread(target=write) for i in range(2)]
-    for t in rthreads + wthreads: t.start()
-    for t in rthreads + wthreads: t.join()
+    for t in rthreads + wthreads:
+        t.start()
+    for t in rthreads + wthreads:
+        t.join()
     print("readers[%d] writers[%d]" % (readers.counter, writers.counter))

--- a/examples/contrib/thread_safe_datastore.py
+++ b/examples/contrib/thread_safe_datastore.py
@@ -22,7 +22,7 @@ class ContextWrapper(object):
             self._enter()
         return self if not self._factory else self._factory()
 
-    def __exit__(self, args):
+    def __exit__(self, *args):
         if self._leave:
             self._leave()
 

--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -576,7 +576,7 @@ class ModbusSerialServer(object):
         if self._connect():
             _logger.debug("Started thread to serve client")
             if not self.handler:
-                self._build_handler()
+                self._build_handler(self.handler)
             while self.is_running:
                 if hasattr(self.handler, "response_manipulator"):
                     self.handler.response_manipulator()


### PR DESCRIPTION
Fix several hundred lint warnings from running `flake8` against `\examples`

Fix a couple of code smells from SonarCloud, and Python2->3 in `\examples`