### PR TITLE
Documentation cleanup and clarification

### DIFF
--- a/doc/source/library/pymodbus.client.asynchronous.async_io.rst
+++ b/doc/source/library/pymodbus.client.asynchronous.async_io.rst
@@ -1,4 +1,4 @@
-pymodbus\.client\.asynchronous\.asyncio package
+pymodbus\.client\.asynchronous\.async_io package
 ===============================================
 
 .. automodule:: pymodbus.client.asynchronous.async_io

--- a/doc/source/library/pymodbus.client.rst
+++ b/doc/source/library/pymodbus.client.rst
@@ -1,10 +1,9 @@
 pymodbus\.client package
 ========================
 
-.. automodule:: pymodbus.client
-    :members:
-    :undoc-members:
-    :show-inheritance:
+Pymodbus offers a :mod:`synchronous client <pymodbus.client.sync>`, and async clients based on :mod:`asyncio <pymodbus.client.asynchronous.async_io>`, :mod:`Tornado <pymodbus.client.asynchronous.tornado>`, and :mod:`Twisted <pymodbus.client.asynchronous.Twisted>`.
+
+Each client shares a :mod:`common client mixin <pymodbus.client.common>` which offers simple methods for reading and writing.
 
 Subpackages
 -----------

--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -58,7 +58,7 @@ class ReadBitsRequestBase(ModbusRequest):
 
 class ReadBitsResponseBase(ModbusResponse):
     """Base class for Messages responding to bit-reading values.
-    
+
     The requested bits can be found in the .bits list.
     """
 
@@ -174,6 +174,7 @@ class ReadCoilsResponse(ReadBitsResponseBase):
 
     The requested coils can be found in boolean form in the .bits list.
     """
+
     function_code = 1
 
     def __init__(self, values=None, **kwargs):
@@ -236,6 +237,7 @@ class ReadDiscreteInputsResponse(ReadBitsResponseBase):
 
     The requested coils can be found in boolean form in the .bits list.
     """
+
     function_code = 2
 
     def __init__(self, values=None, **kwargs):

--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -57,7 +57,10 @@ class ReadBitsRequestBase(ModbusRequest):
 
 
 class ReadBitsResponseBase(ModbusResponse):
-    """Base class for Messages responding to bit-reading values."""
+    """Base class for Messages responding to bit-reading values.
+    
+    The requested bits can be found in the .bits list.
+    """
 
     _rtu_byte_count_pos = 2
 
@@ -67,6 +70,8 @@ class ReadBitsResponseBase(ModbusResponse):
         :param values: The requested values to be returned
         """
         ModbusResponse.__init__(self, **kwargs)
+
+        #: A list of booleans representing bit values
         self.bits = values or []
 
     def encode(self):
@@ -144,9 +149,9 @@ class ReadCoilsRequest(ReadBitsRequestBase):
         request is valid against the current datastore.
 
         :param context: The datastore to request from
-        :returns: The initializes response message, exception message otherwise
+        :returns: An initialized :py:class:`~pymodbus.register_read_message.ReadCoilsResponse`, or an :py:class:`~pymodbus.pdu.ExceptionResponse` if an error occurred
         """
-        if not 1 <= self.count <= 0x7D0:
+        if not (1 <= self.count <= 0x7d0):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
@@ -166,8 +171,9 @@ class ReadCoilsResponse(ReadBitsResponseBase):
     remaining bits in the final data byte will be padded with zeros
     (toward the high order end of the byte). The Byte Count field specifies
     the quantity of complete bytes of data.
-    """
 
+    The requested coils can be found in boolean form in the .bits list.
+    """
     function_code = 1
 
     def __init__(self, values=None, **kwargs):
@@ -205,9 +211,9 @@ class ReadDiscreteInputsRequest(ReadBitsRequestBase):
         request is valid against the current datastore.
 
         :param context: The datastore to request from
-        :returns: The initializes response message, exception message otherwise
+        :returns: An initialized :py:class:`~pymodbus.register_read_message.ReadDiscreteInputsResponse`, or an :py:class:`~pymodbus.pdu.ExceptionResponse` if an error occurred
         """
-        if not 1 <= self.count <= 0x7D0:
+        if not (1 <= self.count <= 0x7d0):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
@@ -227,8 +233,9 @@ class ReadDiscreteInputsResponse(ReadBitsResponseBase):
     remaining bits in the final data byte will be padded with zeros
     (toward the high order end of the byte). The Byte Count field specifies
     the quantity of complete bytes of data.
-    """
 
+    The requested coils can be found in boolean form in the .bits list.
+    """
     function_code = 2
 
     def __init__(self, values=None, **kwargs):
@@ -243,6 +250,7 @@ class ReadDiscreteInputsResponse(ReadBitsResponseBase):
 #  Exported symbols
 # ---------------------------------------------------------------------------#
 __all__ = [
+    "ReadBitsResponseBase",
     "ReadCoilsRequest",
     "ReadCoilsResponse",
     "ReadDiscreteInputsRequest",

--- a/pymodbus/client/asynchronous/async_io/__init__.py
+++ b/pymodbus/client/asynchronous/async_io/__init__.py
@@ -77,15 +77,15 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """
         self._data_received(data)
 
-    def create_future(self):
-        """Helper function to create asyncio Future object
+    def create_future(self):  # pylint: disable=no-self-use
+        """Help function to create asyncio Future object.
 
         :return:
         """
         return asyncio.Future()
 
-    def resolve_future(self, my_future, result):
-        """Resolves the completed future and sets the result
+    def resolve_future(self, my_future, result):  # pylint: disable=no-self-use
+        """Resolve the completed future and sets the result.
 
         :param my_future:
         :param result:
@@ -94,9 +94,8 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         if not my_future.done():
             my_future.set_result(result)
 
-    def raise_future(self, my_future, exc):
-        """
-        Sets exception of a future if not done
+    def raise_future(self, my_future, exc):  # pylint: disable=no-self-use
+        """Set exception of a future if not done.
 
         :param my_future:
         :param exc:
@@ -644,7 +643,7 @@ class AsyncioModbusUdpClient:
 
     def stop(self):
         """Stop connection.
-        
+
         :return:
         """
         # prevent reconnect:

--- a/pymodbus/client/asynchronous/async_io/__init__.py
+++ b/pymodbus/client/asynchronous/async_io/__init__.py
@@ -43,6 +43,7 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """Call when a connection is made.
 
         The transport argument is the transport representing the connection.
+
         :param transport:
         :return:
         """
@@ -56,6 +57,7 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """Call when the connection is lost or closed.
 
         The argument is either an exception object or None
+
         :param reason:
         :return:
         """
@@ -69,24 +71,34 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """Call when some data is received.
 
         data is a non-empty bytes object containing the incoming data.
+
         :param data:
         :return:
         """
         self._data_received(data)
 
-    def create_future(self):  # pylint: disable=no-self-use
-        """Create asyncio Future object."""
+    def create_future(self):
+        """Helper function to create asyncio Future object
+
+        :return:
+        """
         return asyncio.Future()
 
-    def resolve_future(self, my_future, result):  # pylint: disable=no-self-use
-        """Resolve future."""
+    def resolve_future(self, my_future, result):
+        """Resolves the completed future and sets the result
+
+        :param my_future:
+        :param result:
+        :return:
+        """
         if not my_future.done():
             my_future.set_result(result)
 
-    def raise_future(self, my_future, exc):  # pylint: disable=no-self-use
-        """Set exception of a future if not done
+    def raise_future(self, my_future, exc):
+        """
+        Sets exception of a future if not done
 
-        :param f:
+        :param my_future:
         :param exc:
         :return:
         """
@@ -183,6 +195,7 @@ class ModbusClientProtocol(BaseModbusAsyncClientProtocol, asyncio.Protocol):
         """Call when some data is received.
 
         data is a non-empty bytes object containing the incoming data.
+
         :param data:
         :return:
         """
@@ -219,7 +232,7 @@ class ReconnectingAsyncioModbusTcpClient:
     DELAY_MAX_MS = 1000 * 60 * 5
 
     def __init__(self, protocol_class=None, loop=None, **kwargs):
-        """Initialize ReconnectingAsyncioModbusTcpClient
+        """Initialize ReconnectingAsyncioModbusTcpClient.
 
         :param protocol_class: Protocol used to talk to modbus device.
         :param loop: Event loop to use
@@ -258,7 +271,10 @@ class ReconnectingAsyncioModbusTcpClient:
         return await self._connect()
 
     def stop(self):
-        """Stop client."""
+        """Stop client.
+
+        :return:
+        """
         # prevent reconnect:
         self.host = None
 
@@ -606,7 +622,7 @@ class AsyncioModbusUdpClient:
     """Client to connect to modbus device over UDP."""
 
     def __init__(self, host=None, port=502, protocol_class=None, loop=None, **kwargs):
-        """Initialize Asyncio Modbus UDP Client
+        """Initialize Asyncio Modbus UDP Client.
 
         :param host: Host IP address
         :param port: Port to connect
@@ -627,7 +643,10 @@ class AsyncioModbusUdpClient:
         self._proto_args = kwargs
 
     def stop(self):
-        """Stop connection."""
+        """Stop connection.
+        
+        :return:
+        """
         # prevent reconnect:
         # self.host = None
 
@@ -753,7 +772,10 @@ class AsyncioModbusSerialClient:
         return self._connected_event.is_set()
 
     async def connect(self):
-        """Connect Async client."""
+        """Connect Async client.
+
+        :return:
+        """
         _logger.debug(TEXT_CONNECTING)
         try:
             await create_serial_connection(

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -36,6 +36,7 @@ class BaseModbusClient(ModbusClientMixin):
     Derived classes simply need to implement the transport methods and set the correct
     framer.
     """
+
     def __init__(self, framer, **kwargs):
         """Initialize a client instance.
 
@@ -160,7 +161,7 @@ class BaseModbusClient(ModbusClientMixin):
             _logger.exception(exc)
 
     def register(self, function):
-        """Registers a function and sub function class with the decoder
+        """Register a function and sub function class with the decoder.
 
         :param function: Custom function class to register
         :return:

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -31,11 +31,11 @@ _logger = logging.getLogger(__name__)
 class BaseModbusClient(ModbusClientMixin):
     """Interface for a modbus synchronous client.
 
-    Defined here are all the methods for performing the related request
-    methods.  Derived classes simply need to implement the transport
-    methods and set the correct framer.
+    Defined here are all the methods for performing the related
+    request methods.
+    Derived classes simply need to implement the transport methods and set the correct
+    framer.
     """
-
     def __init__(self, framer, **kwargs):
         """Initialize a client instance.
 
@@ -128,7 +128,7 @@ class BaseModbusClient(ModbusClientMixin):
         self.close()
 
     def idle_time(self):
-        """Return bus Idle Time to initiate next transaction.
+        """Bus Idle Time to initiate next transaction
 
         :return: time stamp
         """
@@ -160,7 +160,7 @@ class BaseModbusClient(ModbusClientMixin):
             _logger.exception(exc)
 
     def register(self, function):
-        """Register a function and sub function class with the decoder.
+        """Registers a function and sub function class with the decoder
 
         :param function: Custom function class to register
         :return:

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -148,6 +148,7 @@ class ReadHoldingRegistersResponse(ReadRegistersResponseBase):
 
     The requested registers can be found in the .registers list.
     """
+
     function_code = 3
 
     def __init__(self, values=None, **kwargs):
@@ -203,6 +204,7 @@ class ReadInputRegistersResponse(ReadRegistersResponseBase):
 
     The requested registers can be found in the .registers list.
     """
+
     function_code = 4
 
     def __init__(self, values=None, **kwargs):
@@ -341,6 +343,7 @@ class ReadWriteMultipleRegistersResponse(ModbusResponse):
 
     The requested registers can be found in the .registers list.
     """
+
     function_code = 23
     _rtu_byte_count_pos = 2
 

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -50,7 +50,10 @@ class ReadRegistersRequestBase(ModbusRequest):
 
 
 class ReadRegistersResponseBase(ModbusResponse):
-    """Base class for responding to a modbus register read."""
+    """Base class for responding to a modbus register read.
+
+    The requested registers can be found in the .registers list.
+    """
 
     _rtu_byte_count_pos = 2
 
@@ -60,6 +63,8 @@ class ReadRegistersResponseBase(ModbusResponse):
         :param values: The values to write to
         """
         ModbusResponse.__init__(self, **kwargs)
+
+        #: A list of register values
         self.registers = values or []
 
     def encode(self):
@@ -122,9 +127,9 @@ class ReadHoldingRegistersRequest(ReadRegistersRequestBase):
         """Run a read holding request against a datastore.
 
         :param context: The datastore to request from
-        :returns: An initialized response, exception message otherwise
+        :returns: An initialized :py:class:`~pymodbus.register_read_message.ReadHoldingRegistersResponse`, or an :py:class:`~pymodbus.pdu.ExceptionResponse` if an error occurred
         """
-        if not 1 <= self.count <= 0x7D:
+        if not (1 <= self.count <= 0x7d):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
@@ -140,8 +145,9 @@ class ReadHoldingRegistersResponse(ReadRegistersResponseBase):
     starting register address and the number of registers. In the PDU
     Registers are addressed starting at zero. Therefore registers numbered
     1-16 are addressed as 0-15.
-    """
 
+    The requested registers can be found in the .registers list.
+    """
     function_code = 3
 
     def __init__(self, values=None, **kwargs):
@@ -176,9 +182,9 @@ class ReadInputRegistersRequest(ReadRegistersRequestBase):
         """Run a read input request against a datastore.
 
         :param context: The datastore to request from
-        :returns: An initialized response, exception message otherwise
+        :returns: An initialized :py:class:`~pymodbus.register_read_message.ReadInputRegistersResponse`, or an :py:class:`~pymodbus.pdu.ExceptionResponse` if an error occurred
         """
-        if not 1 <= self.count <= 0x7D:
+        if not (1 <= self.count <= 0x7d):
             return self.doException(merror.IllegalValue)
         if not context.validate(self.function_code, self.address, self.count):
             return self.doException(merror.IllegalAddress)
@@ -194,8 +200,9 @@ class ReadInputRegistersResponse(ReadRegistersResponseBase):
     starting register address and the number of registers. In the PDU
     Registers are addressed starting at zero. Therefore input registers
     numbered 1-16 are addressed as 0-15.
-    """
 
+    The requested registers can be found in the .registers list.
+    """
     function_code = 4
 
     def __init__(self, values=None, **kwargs):
@@ -281,9 +288,9 @@ class ReadWriteMultipleRegistersRequest(ModbusRequest):
         """Run a write single register request against a datastore.
 
         :param context: The datastore to request from
-        :returns: An initialized response, exception message otherwise
+        :returns: An initialized :py:class:`~pymodbus.register_read_message.ReadWriteMultipleRegistersResponse`, or an :py:class:`~pymodbus.pdu.ExceptionResponse` if an error occurred
         """
-        if not 1 <= self.read_count <= 0x07D:
+        if not (1 <= self.read_count <= 0x07d):
             return self.doException(merror.IllegalValue)
         if not 1 <= self.write_count <= 0x079:
             return self.doException(merror.IllegalValue)
@@ -331,8 +338,9 @@ class ReadWriteMultipleRegistersResponse(ModbusResponse):
     The normal response contains the data from the group of registers that
     were read. The byte count field specifies the quantity of bytes to
     follow in the read data field.
-    """
 
+    The requested registers can be found in the .registers list.
+    """
     function_code = 23
     _rtu_byte_count_pos = 2
 
@@ -379,6 +387,7 @@ __all__ = [
     "ReadHoldingRegistersResponse",
     "ReadInputRegistersRequest",
     "ReadInputRegistersResponse",
+    "ReadRegistersResponseBase",
     "ReadWriteMultipleRegistersRequest",
     "ReadWriteMultipleRegistersResponse",
 ]


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
I was having issues with the pymodbus documentation as a new user. I've tried to fix some of the issues I was running up against:

- The return type of request methods was not documented, and the returned base classes were not included in the documentation
- The client documentation page was cluttered and unclear, and needed a "here is the base client, here is the sync client, here are the async clients" explanation
- Documentation for asyncio was not present because the actual pymodbus module is called async_io
- Some docs were broken due to Sphinx syntax errors in the docstrings

The approach I have taken is obviously up for debate (especially exposing the base classes in `__all__`) but I wanted to get the ball rolling with some code :)