### PR TITLE
Add support for byte strings in the device information fields

### DIFF
--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -373,7 +373,7 @@ class ReportSlaveIdRequest(ModbusRequest):
             # Support identity values as bytes data and regular str data
             id_data = []
             for v in information.values():
-                if type(v) is bytes:
+                if isinstance(v, bytes):
                     id_data.append(v)
                 else:
                     id_data.append(v.encode())

--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -369,7 +369,16 @@ class ReportSlaveIdRequest(ModbusRequest):
             reportSlaveIdData = getattr(context, 'reportSlaveIdData', None)
         if not reportSlaveIdData:
             information = DeviceInformationFactory.get(_MCB)
-            identifier = "-".join(information.values()).encode()
+
+            # Support identity values as bytes data and regular str data
+            id_data = []
+            for v in information.values():
+                if type(v) is bytes:
+                    id_data.append(v)
+                else:
+                    id_data.append(v.encode())
+
+            identifier = b"-".join(id_data)
             identifier = identifier or b'Pymodbus'
             reportSlaveIdData = identifier
         return ReportSlaveIdResponse(reportSlaveIdData)

--- a/test/test_other_messages.py
+++ b/test/test_other_messages.py
@@ -87,6 +87,45 @@ class ModbusOtherMessageTest(unittest.TestCase):
         self.assertEqual(response.event_count, 0x12)
         self.assertEqual(response.events, [0x12,0x34,0x56])
 
+    def testReportSlaveIdRequest(self):
+        with mock.patch("pymodbus.other_message.DeviceInformationFactory") as dif:
+            # First test regular identity strings
+            identity = {
+                0x00: 'VN',  # VendorName
+                0x01: 'PC',  # ProductCode
+                0x02: 'REV',  # MajorMinorRevision
+                0x03: 'VU',  # VendorUrl
+                0x04: 'PN',  # ProductName
+                0x05: 'MN',  # ModelName
+                0x06: 'UAN',  # UserApplicationName
+                0x07: 'RA',  # reserved
+                0x08: 'RB',  # reserved
+            }
+            dif.get.return_value = identity
+            expected_identity = "-".join(identity.values()).encode()
+
+            request = ReportSlaveIdRequest()
+            response = request.execute()
+            self.assertEqual(response.identifier, expected_identity)
+
+            # Change to byte strings and test again (final result should be the same)
+            identity = {
+                0x00: b'VN',  # VendorName
+                0x01: b'PC',  # ProductCode
+                0x02: b'REV',  # MajorMinorRevision
+                0x03: b'VU',  # VendorUrl
+                0x04: b'PN',  # ProductName
+                0x05: b'MN',  # ModelName
+                0x06: b'UAN',  # UserApplicationName
+                0x07: b'RA',  # reserved
+                0x08: b'RB',  # reserved
+            }
+            dif.get.return_value = identity
+
+            request = ReportSlaveIdRequest()
+            response = request.execute()
+            self.assertEqual(response.identifier, expected_identity)
+
     def testReportSlaveId(self):
         with mock.patch("pymodbus.other_message.DeviceInformationFactory") as dif:
             dif.get.return_value = dict()


### PR DESCRIPTION
I'm trying to emulate a modbus device that has non ASCII data in the vendor name part of the device information. The library cannot correctly encode this, because when encoding this info it is encoded as utf-8. For example, a vendor name of "\xF0\x12\x34" ends up as b"\xC3\xB0\x12\x34" in the encoded payload.

This PR changes the encoding of the device information fields to support both ```bytes``` objects and ```str``` objects.

The appropriate unit tests have been added.