### PR TITLE
Adjusting sync modbus server to accept custom ModusRequestHandler

### DIFF
--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -541,7 +541,8 @@ class ModbusSerialServer(object):
         self.socket = None
         if self._connect():
             self.is_running = True
-            self._build_handler()
+            self._build_handler(kwargs.get('handler',
+                                           CustomSingleRequestHandler))
 
     def _connect(self):
         """ Connect to the serial server
@@ -560,19 +561,19 @@ class ModbusSerialServer(object):
             _logger.error(msg)
         return self.socket is not None
 
-    def _build_handler(self):
+    def _build_handler(self, handler):
         """ A helper method to create and monkeypatch
             a serial handler.
+        :param handler: a custom handler, uses ModbusSingleRequestHandler if set to None
 
         :returns: A patched handler
         """
-
         request = self.socket
         request.send = request.write
         request.recv = request.read
-        self.handler = CustomSingleRequestHandler(request,
-                                                  (self.device, self.device),
-                                                  self)
+        self.handler = handler(request,
+                               (self.device, self.device),
+                               self)
 
     def serve_forever(self):
         """ Callback for connecting a new client thread


### PR DESCRIPTION
This allows to have a custom send method triggering a hardware Driver Enable (DE) using the RTS pin e.g. on Raspberry Pis for the server (modbus slave) as well. This solution is based on https://github.com/riptideio/pymodbus/issues/33#issuecomment-939328396 (Thanks for this one!)

Something similar is already available for the async-io server, but there it is hard to get the correct timing for the RTS pin.

```python
class MyModbusSingleRequestHandler(CustomSingleRequestHandler):
    def __init__(self, *args, **kwargs):
        super().__init__(*args, **kwargs)

    def send(self, message):
        if message.should_respond:
            pdu = self.framer.buildPacket(message)
            tx_time = (len(pdu) + 1) * (10.0 / self.request.baudrate)
            self.request.setRTS(False)
            time.sleep(0.001)
            status = self.request.send(pdu)
            time.sleep(tx_time)
            self.request.setRTS(True)
            logging.debug('send: [%s]- %s' % (message, b2a_hex(pdu)))
            return status

server = StartSerialServer(context, framer=ModbusAsciiFramer, identity=identity,
                           port='/dev/ttyAMA1', timeout=.005, baudrate=9600, handler=MyModbusSingleRequestHandler)
```

