### PR TITLE
708 Implement ReadFileRecordRequest.get_response_pdu_size() to ensure complete record

### DIFF
--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -144,7 +144,7 @@ class ReadFileRecordRequest(ModbusRequest):
         :return: 
         """
         for record in self.records:
-            self.count += record.record_length
+            self.count+=record.record_length
 
         return 4 + self.count
 

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -140,13 +140,16 @@ class ReadFileRecordRequest(ModbusRequest):
     
     def get_response_pdu_size(self):
         """
-        Func_code (1 byte) + Byte Count(1 byte) + Byte Count2 (1 byte) + Reference Type (1 byte) + registers to read for file
+        Func_code (1 byte) + Response Byte Count(1 byte) +
+            N * (File Response Byte Count (1 byte) + Reference Type (1 byte) + 2 * registers to read for file record)
+            where N = record sub-request count.
         :return: 
         """
+        self.count = 0
         for record in self.records:
-            self.count+=record.record_length
+            self.count+= record.record_length * 2 + 2 if record.record_length else 0
 
-        return 4 + self.count
+        return 2 + self.count
 
 class ReadFileRecordResponse(ModbusResponse):
     """Read file record response.

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -90,7 +90,8 @@ class ReadFileRecordRequest(ModbusRequest):
         :param records: The file record requests to be read
         """
         ModbusRequest.__init__(self, **kwargs)
-        self.records = records or []
+        self.records  = records or []
+        self.count = 0
 
     def encode(self):
         """Encode the request packet.
@@ -136,7 +137,16 @@ class ReadFileRecordRequest(ModbusRequest):
         # is too big, return an error.
         files = []
         return ReadFileRecordResponse(files)
+    
+    def get_response_pdu_size(self):
+        """
+        Func_code (1 byte) + Byte Count(1 byte) + Byte Count2 (1 byte) + Reference Type (1 byte) + registers per record
+        :return: 
+        """
+        for record in self.records:
+            self.count += record.record_length
 
+        return 4 + self.count
 
 class ReadFileRecordResponse(ModbusResponse):
     """Read file record response.

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -140,7 +140,7 @@ class ReadFileRecordRequest(ModbusRequest):
     
     def get_response_pdu_size(self):
         """
-        Func_code (1 byte) + Byte Count(1 byte) + Byte Count2 (1 byte) + Reference Type (1 byte) + registers per record
+        Func_code (1 byte) + Byte Count(1 byte) + Byte Count2 (1 byte) + Reference Type (1 byte) + registers to read for file
         :return: 
         """
         for record in self.records:

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -90,7 +90,7 @@ class ReadFileRecordRequest(ModbusRequest):
         :param records: The file record requests to be read
         """
         ModbusRequest.__init__(self, **kwargs)
-        self.records  = records or []
+        self.records = records or []
         self.count = 0
 
     def encode(self):
@@ -137,19 +137,20 @@ class ReadFileRecordRequest(ModbusRequest):
         # is too big, return an error.
         files = []
         return ReadFileRecordResponse(files)
-    
+
     def get_response_pdu_size(self):
-        """
+        """Get response pdu size.
+
         Func_code (1 byte) + Response Byte Count(1 byte) +
             N * (File Response Byte Count (1 byte) + Reference Type (1 byte) + 2 * registers to read for file record)
             where N = record sub-request count.
-        :return: 
         """
         self.count = 0
         for record in self.records:
-            self.count+= record.record_length * 2 + 2 if record.record_length else 0
+            self.count += record.record_length * 2 + 2 if record.record_length else 0
 
         return 2 + self.count
+
 
 class ReadFileRecordResponse(ModbusResponse):
     """Read file record response.


### PR DESCRIPTION
Possible fix to #708 

ReadFileRecordRequest does not include an implementation of get_response_pdu_size() so the rtu_framer completes prior to a full response received. Causes many errors during a file read operation.
