### PR TITLE
Properly initialize non-default framer in async client

### DIFF
--- a/pymodbus/client/asynchronous/mixins.py
+++ b/pymodbus/client/asynchronous/mixins.py
@@ -31,8 +31,9 @@ class BaseAsyncModbusClient(BaseModbusClient):
         self._connected = False
         self._timeout = timeout
 
+        framer_inst = framer(ClientDecoder()) if framer else ModbusSocketFramer(ClientDecoder())
         super(BaseAsyncModbusClient, self).__init__(
-            framer or ModbusSocketFramer(ClientDecoder()), **kwargs
+            framer_inst, **kwargs
         )
 
 


### PR DESCRIPTION
Fixes #712.

Not 100% sure if this is the most elegant fix but it works to get ModbusRtuFramer usable with async clients.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
