### PR TITLE
Solve issue #721 (selector not valid)

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -290,7 +290,11 @@ class ModbusTcpClient(BaseModbusClient):
         time_ = time.time()
         end = time_ + timeout
         while recv_size > 0:
-            ready = select.select([self.socket], [], [], end - time_)
+            try:
+                ready = select.select([self.socket], [], [], end - time_)
+            except ValueError:
+                return self._handle_abrupt_socket_close(
+                    size, data, time.time() - time_)
             if ready[0]:
                 recv_data = self.socket.recv(recv_size)
                 if recv_data == b'':


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
client/sync.py/_recv contains a select call, which causes problems if the server aborts, without closing the socket properly.

The loop means that the socket can go "invalid" while waiting for data.

This is tested with a software server, that does assert, after having read a couple of times. This is however a kind of timing issue, because the client needs to be in the _recv loop.


fixes #721 