### PR TITLE
Solve CI. problem with pypy3.7 on macOS.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os.runs-on }}
     container: ${{ matrix.os.container[matrix.python.docker] }}
     # present runtime seems to be about 1 minute 30 seconds
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # directory.
 
 [tox]
-envlist = py{37,38,39,py37,py38,py39}
+envlist = py{37,38,39,py37}
 
 [testenv]
 deps = -r requirements-tests.txt


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
pypy3.7 takes very long to setup on macOS so timeout changed to 15minutes.