### PR TITLE
Add pypy3.8, 3.9, 3.10 to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,8 @@ jobs:
             docker: 3.9
             matrix: 3.9
             implementation: cpython
-          - name: CPython 3.10
-            tox: py310
+          - name: 'CPython 3.10'
+            tox: 'py310'
             action: '3.10'
             docker: '3.10'
             matrix: '3.10'
@@ -79,6 +79,27 @@ jobs:
             action: pypy-3.7
             docker: pypy3.7
             matrix: 3.7
+            implementation: pypy
+            openssl_msvc_version: 2019
+          - name: PyPy 3.8
+            tox: pypy38
+            action: pypy-3.8
+            docker: pypy3.8
+            matrix: 3.8
+            implementation: pypy
+            openssl_msvc_version: 2019
+          - name: PyPy 3.9
+            tox: pypy39
+            action: pypy-3.9
+            docker: pypy3.9
+            matrix: 3.9
+            implementation: pypy
+            openssl_msvc_version: 2019
+          - name: 'PyPy 3.10'
+            tox: 'pypy310'
+            action: 'pypy-3.10'
+            docker: 'pypy3.10'
+            matrix: '3.10'
             implementation: pypy
             openssl_msvc_version: 2019
         arch:
@@ -103,6 +124,11 @@ jobs:
               implementation: pypy
             arch:
               matrix: x64
+          - os:
+              matrix: windows
+            python:
+              implementation: pypy
+              matrix: 3.8
     env:
       # Should match name above
       JOB_NAME: ${{ matrix.task.name }} - ${{ matrix.os.name }} ${{ matrix.python.name }} ${{ matrix.arch.name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,20 +88,6 @@ jobs:
             matrix: 3.8
             implementation: pypy
             openssl_msvc_version: 2019
-          - name: PyPy 3.9
-            tox: pypy39
-            action: pypy-3.9
-            docker: pypy3.9
-            matrix: 3.9
-            implementation: pypy
-            openssl_msvc_version: 2019
-          - name: 'PyPy 3.10'
-            tox: 'pypy310'
-            action: 'pypy-3.10'
-            docker: 'pypy3.10'
-            matrix: '3.10'
-            implementation: pypy
-            openssl_msvc_version: 2019
         arch:
           - name: x86
             action: x86

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.swp
 build/
 dist/
+venv/
 pymodbus.egg-info/
 .coverage
 .vscode

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pypy38 does not work on windows, due to an internal error.
-envlist = py{37,38,39,310,py37,py38,py39,py310}
+envlist = py{37,38,39,310,py37,py38}
 
 [testenv]
 deps = -r requirements-tests.txt

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,8 @@
 # directory.
 
 [tox]
-envlist = py{37,38,39,310,py37}
+# pypy38 does not work on windows, due to an internal error.
+envlist = py{37,38,39,310,py37,py38,py39,py310}
 
 [testenv]
 deps = -r requirements-tests.txt


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
we test Cpython on all platforms with 3.7, 3.8, 3.9, 3.10

But we only test pypy with 3.7

Let's change that.