### PR TITLE
Python 3.7 End Of Life.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
             runs-on: ubuntu-latest
             matrix: linux
             container:
-              3.7: docker://python:3.7-buster
               3.8: docker://python:3.8-buster
               3.9: docker://python:3.9-buster
               3.10: docker://python:3.10-buster
@@ -50,12 +49,6 @@ jobs:
               x86: win32
               x64: win64
         python:
-          - name: CPython 3.7
-            tox: py37
-            action: 3.7
-            docker: 3.7
-            matrix: 3.7
-            implementation: cpython
           - name: CPython 3.8
             tox: py38
             action: 3.8
@@ -74,13 +67,6 @@ jobs:
             docker: '3.10'
             matrix: '3.10'
             implementation: cpython
-          - name: PyPy 3.7
-            tox: pypy37
-            action: pypy-3.7
-            docker: pypy3.7
-            matrix: 3.7
-            implementation: pypy
-            openssl_msvc_version: 2019
           - name: PyPy 3.8
             tox: pypy38
             action: pypy-3.8

--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,9 @@ Supported versions
 
 Version `2.5.3 <https://github.com/riptideio/pymodbus/releases/tag/v2.5.3>`_ is the last 2.x release with support to python2.7.x and is in maintenance mode.
 
-Version `3.0.0dev3 <https://github.com/riptideio/pymodbus/releases/tag/v3.0.0dev3>`_ is the current prerelease of 3.0.0 (Supports only Python >=3.7)
+Version `3.0.0dev4 <https://github.com/riptideio/pymodbus/releases/tag/v3.0.0dev3>`_ is the current prerelease of 3.0.0 (Supports only Python >=3.8)
+
+Remark: "Supports only" means that we only test with those versions, lower versions (e.g. 3.7) might work typically depending on the actual setup.
 
 .. important::
    **Note 3.0.0 is a major release with a number of incompatible changes.**

--- a/doc/INSTALL
+++ b/doc/INSTALL
@@ -1,7 +1,7 @@
 Requirements
 -------------
 
-* Python 3.7 or later.
+* Python 3.8 or later.
 * Python Twisted or Tornado (if not using asyncio for async client and server),
 remark Twisted and Tornado are in maintenance mode, and might either be dropped or supplied as plugins in the future.
 

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -483,7 +483,6 @@ class ModbusTcpServer: # pylint: disable=too-many-instance-attributes
         # constructors cannot be declared async, so we have to
         # defer the initialization of the server
         self.server = None
-        # start_serving is new in version 3.7
         self.server_factory = self.loop.create_server(
             lambda: self.handler(self),
             *self.address,

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ setup(
     """,
     classifiers=[
         'Development Status :: 4 - Beta',
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -78,7 +77,7 @@ setup(
     platforms=['Linux', 'Mac OS X', 'Win'],
     include_package_data=True,
     zip_safe=True,
-    python_requires='>=3.7',
+    python_requires='>=3.8',
     install_requires=install_requires,
     extras_require={
         'quality': [
@@ -101,7 +100,7 @@ setup(
         'tornado': [
             'tornado == 4.5.3'
         ],
-        'repl:python_version >= "3.7"': [
+        'repl:python_version >= "3.8"': [
             'click>=7.0',
             'prompt-toolkit>=3.0.8',
             'pygments>=2.2.0',

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # pypy38 does not work on windows, due to an internal error.
-envlist = py{37,38,39,310,py37,py38}
+envlist = py{38,39,310,py38}
 
 [testenv]
 deps = -r requirements-tests.txt


### PR DESCRIPTION
Python 3.7 has been marked "End Of Life", therefore we no longer
support it or test it.

Python 3.7 is only receiving security patches, and the official EOL is 2023-06-27 with only 1 more security patch scheduled.

Python 3.7 is currently causing huge delays in our CI (15minutes runtime instead of 2-3minutes) and is also causing a number of "if PYTHON_VERSION > (3, 7):" in our code.



<!--  Please raise your PR's against the `dev` branch instead of `master` -->
