### PR TITLE
Jump timeout to 25 minutes, pypy3.7 fails too often on timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     container: ${{ matrix.os.container[matrix.python.docker] }}
     # present runtime seems to be about 2 minutes
     # with pypy being the exception (10 minutes)
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
