### PR TITLE
No longer accept pylint errors in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
         task:
           - name: pylint
             tox: pylint
-            continue_on_error: true
+            # continue_on_error: true
           - name: flake8
             tox: flake8
             continue_on_error: true

--- a/pymodbus/client/common.py
+++ b/pymodbus/client/common.py
@@ -55,7 +55,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = ReadCoilsRequest(address, count, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def read_discrete_inputs(self, address, count=1, **kwargs):
         '''
@@ -66,7 +66,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = ReadDiscreteInputsRequest(address, count, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def write_coil(self, address, value, **kwargs):
         '''
@@ -77,7 +77,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = WriteSingleCoilRequest(address, value, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def write_coils(self, address, values, **kwargs):
         '''
@@ -88,7 +88,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = WriteMultipleCoilsRequest(address, values, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def write_register(self, address, value, **kwargs):
         '''
@@ -99,7 +99,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = WriteSingleRegisterRequest(address, value, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def write_registers(self, address, values, **kwargs):
         '''
@@ -110,7 +110,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = WriteMultipleRegistersRequest(address, values, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def read_holding_registers(self, address, count=1, **kwargs):
         '''
@@ -121,7 +121,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = ReadHoldingRegistersRequest(address, count, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def read_input_registers(self, address, count=1, **kwargs):
         '''
@@ -132,7 +132,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = ReadInputRegistersRequest(address, count, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def readwrite_registers(self, *args, **kwargs):
         '''
@@ -145,7 +145,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = ReadWriteMultipleRegistersRequest(*args, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
     def mask_write_register(self, *args, **kwargs):
         '''
@@ -157,7 +157,7 @@ class ModbusClientMixin:
         :returns: A deferred response handle
         '''
         request = MaskWriteRegisterRequest(*args, **kwargs)
-        return self.execute(request)
+        return self.execute(request) # pylint: disable=no-member
 
 #---------------------------------------------------------------------------#
 # Exported symbols

--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -7,8 +7,8 @@ import logging
 import traceback
 from binascii import b2a_hex
 import socket
-import serial
 import socketserver
+import serial
 
 from pymodbus.constants import Defaults
 from pymodbus.utilities import hexlify_packets

--- a/test/test_server_sync.py
+++ b/test/test_server_sync.py
@@ -3,6 +3,7 @@
 import ssl
 import socket
 import unittest
+import socketserver
 from unittest.mock import patch, Mock
 import pytest
 import serial
@@ -29,7 +30,6 @@ from pymodbus.exceptions import NotImplementedException
 from pymodbus.bit_read_message import ReadCoilsRequest, ReadCoilsResponse
 from pymodbus.datastore import ModbusServerContext
 from pymodbus.transaction import ModbusTlsFramer
-import socketserver
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Solve pylint problems due to new pylintrc.

Update CI to fail test/pylint if there are pylint errors.