### PR TITLE
(merge 5): remove __future__ since the functions are part of python 3.

### DIFF
--- a/examples/common/custom_datablock.py
+++ b/examples/common/custom_datablock.py
@@ -4,7 +4,6 @@
 This is an example of performing custom logic after a value has been
 written to the datastore.
 """
-from __future__ import print_function
 import logging
 
 # --------------------------------------------------------------------------- #

--- a/examples/common/performance.py
+++ b/examples/common/performance.py
@@ -7,7 +7,6 @@ modbus client.
 # --------------------------------------------------------------------------- #
 # import the necessary modules
 # --------------------------------------------------------------------------- #
-from __future__ import print_function
 import logging
 import os
 from threading import Lock, Thread as tWorker

--- a/examples/contrib/message_parser.py
+++ b/examples/contrib/message_parser.py
@@ -12,7 +12,7 @@ using the supplied framers for a number of protocols:
 # -------------------------------------------------------------------------- #
 # import needed libraries
 # -------------------------------------------------------------------------- #
-from __future__ import print_function
+
 import logging
 import collections
 import textwrap

--- a/ez_setup.py
+++ b/ez_setup.py
@@ -1,6 +1,5 @@
 #!python
-"""Ez_setup"""
-from __future__ import print_function
+"""Ez_setup."""
 import os
 import sys
 """Bootstrap setuptools installation

--- a/pymodbus/client/asynchronous/factory/__init__.py
+++ b/pymodbus/client/asynchronous/factory/__init__.py
@@ -1,2 +1,1 @@
 """Factory class."""
-from __future__ import absolute_import, unicode_literals

--- a/pymodbus/client/asynchronous/factory/serial.py
+++ b/pymodbus/client/asynchronous/factory/serial.py
@@ -1,6 +1,4 @@
 """Factory to create asynchronous serial clients based on twisted/tornado/asyncio."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import logging
 import asyncio
 

--- a/pymodbus/client/asynchronous/factory/tcp.py
+++ b/pymodbus/client/asynchronous/factory/tcp.py
@@ -1,6 +1,4 @@
 """Factory to create asynchronous tcp clients based on twisted/tornado/asyncio."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import logging
 import asyncio
 

--- a/pymodbus/client/asynchronous/factory/tls.py
+++ b/pymodbus/client/asynchronous/factory/tls.py
@@ -1,6 +1,4 @@
 """Factory to create asynchronous tls clients based on asyncio."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import logging
 import asyncio
 

--- a/pymodbus/client/asynchronous/factory/udp.py
+++ b/pymodbus/client/asynchronous/factory/udp.py
@@ -1,6 +1,4 @@
 """UDP implementation."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
 import logging
 import asyncio
 

--- a/pymodbus/client/asynchronous/schedulers/__init__.py
+++ b/pymodbus/client/asynchronous/schedulers/__init__.py
@@ -1,5 +1,4 @@
 """Backend schedulers to use with generic Async clients."""
-from __future__ import unicode_literals
 
 REACTOR = "reactor"
 IO_LOOP = "io_loop"

--- a/pymodbus/client/asynchronous/serial.py
+++ b/pymodbus/client/asynchronous/serial.py
@@ -1,7 +1,4 @@
 """SERIAL communication."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import logging
 from pymodbus.client.asynchronous.factory.serial import get_factory
 from pymodbus.transaction import (

--- a/pymodbus/client/asynchronous/tcp.py
+++ b/pymodbus/client/asynchronous/tcp.py
@@ -1,7 +1,4 @@
 """TCP communication."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import logging
 from pymodbus.client.asynchronous.factory.tcp import get_factory
 from pymodbus.constants import Defaults

--- a/pymodbus/client/asynchronous/thread.py
+++ b/pymodbus/client/asynchronous/thread.py
@@ -1,10 +1,6 @@
 """Thread setup."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
-from threading import Thread
-
 import logging
+from threading import Thread
 
 _logger = logging.getLogger(__name__)
 

--- a/pymodbus/client/asynchronous/tls.py
+++ b/pymodbus/client/asynchronous/tls.py
@@ -1,7 +1,4 @@
 """TLS communication."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import logging
 from pymodbus.client.asynchronous.factory.tls import get_factory
 from pymodbus.constants import Defaults

--- a/pymodbus/client/asynchronous/tornado/__init__.py
+++ b/pymodbus/client/asynchronous/tornado/__init__.py
@@ -1,10 +1,6 @@
 """Asynchronous framework adapter for tornado."""
-from __future__ import unicode_literals
-
-import abc
-
 import logging
-
+import abc
 import time
 import socket
 from serial import Serial

--- a/pymodbus/client/asynchronous/twisted/__init__.py
+++ b/pymodbus/client/asynchronous/twisted/__init__.py
@@ -30,7 +30,6 @@ Another example::
        reactor.callLater(1, process)
        reactor.run()
 """
-from __future__ import unicode_literals
 import logging
 
 from twisted.internet import defer, protocol

--- a/pymodbus/client/asynchronous/udp.py
+++ b/pymodbus/client/asynchronous/udp.py
@@ -1,7 +1,4 @@
 """UDP communication."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
-
 import logging
 from pymodbus.constants import Defaults
 from pymodbus.client.asynchronous.factory.udp import get_factory

--- a/pymodbus/repl/__init__.py
+++ b/pymodbus/repl/__init__.py
@@ -2,4 +2,3 @@
 
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 """
-from __future__ import absolute_import, unicode_literals

--- a/pymodbus/repl/client/completer.py
+++ b/pymodbus/repl/client/completer.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
-from __future__ import absolute_import, unicode_literals
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.styles import Style
 from prompt_toolkit.filters import Condition

--- a/pymodbus/repl/client/helper.py
+++ b/pymodbus/repl/client/helper.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
-from __future__ import absolute_import, unicode_literals
 import json
 from collections import OrderedDict
 import inspect

--- a/pymodbus/repl/client/main.py
+++ b/pymodbus/repl/client/main.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
-from __future__ import absolute_import, unicode_literals
 import logging
 import sys
 import os.path

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -3,7 +3,6 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
-from __future__ import absolute_import, unicode_literals
 import functools
 from pymodbus.pdu import ModbusExceptions, ExceptionResponse
 from pymodbus.exceptions import ModbusIOException


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
__future__ was needed to have compatibility between python 2 and python 3, however all functions are part of python 3 (all versions).

DO NOT merge before https://github.com/riptideio/pymodbus/pull/872 is merged, in order to keep important history.