### PR TITLE
Fix version check when importing CancelledError

### DIFF
--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -14,7 +14,7 @@ from pymodbus.server.reactive.main import (
 from pymodbus.server.reactive.default_config import DEFUALT_CONFIG
 from pymodbus.repl.server.cli import run_repl
 
-if sys.version_info > (3, 7):
+if sys.version_info >= (3, 8):
     CANCELLED_ERROR = asyncio.exceptions.CancelledError
 else:
     CANCELLED_ERROR = asyncio.CancelledError  # pylint: disable=invalid-name


### PR DESCRIPTION
This ensures that all Python 3.7.x versions and earlier do not depend on the existence of `asyncio.exceptions`.

This is just the PR form of the suggestion made by @dhoomakethu in #690. Admittedly very low hanging fruit as far as contributions go :)

Fixes #690 