### PR TITLE
Move create_server to serve_forever()

### DIFF
--- a/test/test_server_asyncio.py
+++ b/test/test_server_asyncio.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python3
 """Test server asyncio."""
+from asyncio import CancelledError
 import logging
 import asyncio
-import time
 import ssl
+from unittest.mock import AsyncMock, Mock, patch
+import unittest
 import pytest
-import asynctest
-from asynctest.mock import patch, Mock
 
 from pymodbus.device import ModbusDeviceIdentification
 from pymodbus.server.async_io import (
@@ -20,13 +20,76 @@ from pymodbus.datastore import ModbusSequentialDataBlock
 from pymodbus.datastore import ModbusSlaveContext, ModbusServerContext
 from pymodbus.exceptions import NoSuchSlaveException
 
-# ---------------------------------------------------------------------------#
-# Fixture
-# ---------------------------------------------------------------------------#
 _logger = logging.getLogger()
 
+SERV_IP = "127.0.0.1"
+SERV_ADDR = ("127.0.0.1", 0)
+TEST_DATA = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"
 
-class AsyncioServerTest(asynctest.TestCase):  # pylint: disable=too-many-public-methods
+
+class BasicClient(asyncio.BaseProtocol):
+    """Basic client."""
+
+    connected = None
+    data = None
+    dataTo = None
+    received_data = None
+    done = None
+    eof = None
+    transport = None
+    protocol = None
+
+    def connection_made(self, transport):
+        """Get Connection made."""
+        _logger.debug("TEST Client connected")
+        if BasicClient.connected is not None:
+            BasicClient.connected.set_result(True)
+
+        self.transport = transport
+        if BasicClient.data is not None:
+            _logger.debug("TEST Client write data")
+            self.transport.write(BasicClient.data)
+        if BasicClient.dataTo is not None:
+            _logger.debug("TEST Client sendTo data")
+            self.transport.sendto(BasicClient.dataTo)
+
+    def data_received(self, data):  # pylint: disable=no-self-use
+        """Get Data received."""
+        _logger.debug("TEST Client data received")
+        BasicClient.received_data = data
+        if BasicClient.done is not None:
+            BasicClient.done.set_result(True)
+
+    def datagram_received(self, data, addr):  # pylint: disable=unused-argument
+        """Get Datagram received."""
+        _logger.debug("TEST Client datagram received")
+        BasicClient.received_data = data
+        if BasicClient.done is not None:
+            BasicClient.done.set_result(True)
+        self.transport.close()
+
+    def connection_lost(self, exc):
+        """EOF received."""
+        txt = f"TEST Client stream lost: {exc}"
+        _logger.debug(txt)
+        if BasicClient.eof:
+            BasicClient.eof.set_result(True)
+
+    @classmethod
+    def clear(cls):
+        """Prepare for new round"""
+        if BasicClient.transport:
+            BasicClient.transport.close()
+            BasicClient.transport = None
+        BasicClient.data = None
+        BasicClient.connected = None
+        BasicClient.done = None
+        BasicClient.received_data = None
+        BasicClient.eof = None
+        BasicClient.protocol = None
+
+
+class AsyncioServerTest(unittest.IsolatedAsyncioTestCase):  # pylint: disable=too-many-public-methods
     """Unittest for the pymodbus.server.asyncio module.
 
     The scope of this unit test is the life-cycle management of the network
@@ -35,378 +98,258 @@ class AsyncioServerTest(asynctest.TestCase):  # pylint: disable=too-many-public-
     This unittest suite does not attempt to test any of the underlying protocol details
     """
 
-    # -----------------------------------------------------------------------#
-    #  Setup/TearDown
-    # -----------------------------------------------------------------------#
-    def setUp(self):
-        """Initialize the test environment by setting up a dummy store and context."""
+    def __init__(self, name):
+        """Initialize."""
+        super().__init__(name)
         self.store = ModbusSlaveContext(di=ModbusSequentialDataBlock(0, [17] * 100),
                                         co=ModbusSequentialDataBlock(0, [17] * 100),
                                         hr=ModbusSequentialDataBlock(0, [17] * 100),
                                         ir=ModbusSequentialDataBlock(0, [17] * 100))
         self.context = ModbusServerContext(slaves=self.store, single=True)
+        self.identity = ModbusDeviceIdentification(info_name={'VendorName': 'VendorName'})
+        self.server = None
+        self.task = None
+        self.loop = None
+
+    # -----------------------------------------------------------------------#
+    #  Setup/TearDown
+    # -----------------------------------------------------------------------#
+    def setUp(self):
+        """Initialize the test environment by setting up a dummy store and context."""
+
+    async def asyncSetUp(self):
+        """Initialize the test environment by setting up a dummy store and context."""
+        self.loop = asyncio.get_running_loop()
+
+    async def asyncTearDown(self):
+        """Clean up the test environment"""
+        if self.server is not None:
+            self.server.server_close()
+            self.server = None
+        if self.task is not None:
+            await asyncio.sleep(0.1)
+            if not self.task.cancelled():
+                self.task.cancel()
+                try:
+                    await self.task
+                except CancelledError:
+                    pass
+                except Exception as exc:  # pylint: disable=broad-except
+                    pytest.fail(f"Exception in task serve_forever: {exc} ")
+                self.assertTrue(self.task.cancelled())
+                self.task = None
+        self.context = ModbusServerContext(slaves=self.store, single=True)
+        BasicClient.clear()
 
     def tearDown(self):
-        """Clean up the test environment"""
+        """Clean up the test environment."""
+
+    def handle_task(self, result):  # pylint: disable=no-self-use
+        """Handle task exit."""
+        try:
+            result = result.result()
+        except CancelledError:
+            pass
+        except Exception as exc:  # pylint: disable=broad-except
+            pytest.fail(f"Exception in task serve_forever: {exc} ")
+
+    async def start_server(self, do_forever=True, do_defer=True, do_tls=False, do_udp=False, do_ident=False):
+        """Handle setup and control of tcp server."""
+        args = {
+            'context': self.context,
+            'address': SERV_ADDR,
+            'defer_start': do_defer,
+        }
+        if do_ident:
+            args['identity'] = self.identity
+        if do_tls:
+            self.server = await StartTlsServer(**args)
+        elif do_udp:
+            self.server = await StartUdpServer(**args)
+        else:
+            self.server = await StartTcpServer(**args)
+        self.assertIsNotNone(self.server)
+        if do_forever:
+            self.task = asyncio.create_task(self.server.serve_forever())
+            self.task.add_done_callback(self.handle_task)
+            self.assertFalse(self.task.cancelled())
+            await asyncio.wait_for(self.server.serving, timeout=0.1)
+            if not do_udp:
+                self.assertIsNotNone(self.server.server)
+        else:
+            self.assertIsNone(self.server.server)
+        self.assertEqual(self.server.control.Identity.VendorName, 'VendorName')
+        await asyncio.sleep(0.1)
+
+    async def connect_server(self):
+        """Handle connect to server"""
+        BasicClient.connected = self.loop.create_future()
+        BasicClient.done = self.loop.create_future()
+        BasicClient.eof = self.loop.create_future()
+        random_port = self.server.server.sockets[0].getsockname()[1]  # get the random server port
+        BasicClient.transport, BasicClient.protocol = await self.loop.create_connection(BasicClient, host='127.0.0.1', port=random_port)
+        await asyncio.wait_for(BasicClient.connected, timeout=0.1)
+        await asyncio.sleep(0.1)
 
     # -----------------------------------------------------------------------#
     #  Test ModbusConnectedRequestHandler
     # -----------------------------------------------------------------------#
 
-    async def test_start_tcp_server(self):
+    async def test_async_start_server_no_loop(self):
         """Test that the modbus tcp asyncio server starts correctly"""
-        identity = ModbusDeviceIdentification(info_name={'VendorName': 'VendorName'})
-        self.loop = asynctest.Mock(self.loop)  # pylint: disable=attribute-defined-outside-init
-        server = await StartTcpServer(context=self.context, loop=self.loop, identity=identity)
-        self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-        self.loop.create_server.assert_called_once()
+        await self.start_server(False)
 
-    async def test_tcp_server_serve_no_defer(self):
-        """Test StartTcpServer without deferred start (immediate execution of server)"""
-        with patch('asyncio.base_events.Server.serve_forever',  # NOSONAR
-                   new_callable=asynctest.CoroutineMock) as serve:
-            await StartTcpServer(context=self.context, address=("127.0.0.1",
-                                                                0), loop=self.loop, defer_start=False)
-            serve.assert_awaited()
+    async def test_async_start_server(self):
+        """Test that the modbus tcp asyncio server starts correctly"""
+        await self.start_server()
 
-    async def test_tcp_server_serve_forever_twice(self):
+    async def test_async_tcp_server_serve_forever_twice(self):
         """Call on serve_forever() twice should result in a runtime error"""
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-        await server.serving
+        await self.start_server()
         with self.assertRaises(RuntimeError):
+            await self.server.serve_forever()
 
-            await server.serve_forever()
-        server.server_close()
-
-    async def test_tcp_server_receive_data(self):
+    async def test_async_tcp_server_receive_data(self):
         """Test data sent on socket is received by internals - doesn't not process data"""
-        data = b'\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-
-        await server.serving
+        BasicClient.data = b'\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
+        await self.start_server()
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',  # NOSONAR
                    new_callable=Mock) as process:
-            # process = server.framer.processIncomingPacket = Mock()
-            connected = self.loop.create_future()
-            random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-
-            class BasicClient(asyncio.BaseProtocol):
-                """Basic client."""
-
-                def connection_made(self, transport):
-                    """Get Connection made."""
-                    self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                    self.transport.write(data)
-                    connected.set_result(True)
-
-                def eof_received(self):
-                    """EOF received."""
-
-            await self.loop.create_connection(BasicClient, host='127.0.0.1', port=random_port)
-            await asyncio.sleep(0.1)  # this may be better done
-            # by making an internal hook in the actual implementation
-            # if this unit test fails on a machine,
-            # see if increasing the sleep time makes a difference,
-            # if it does blame author for a fix
-
+            await self.connect_server()
             process.assert_called_once()
-            self.assertTrue(process.call_args[1]["data"] == data)
-            server.server_close()
+            self.assertTrue(process.call_args[1]["data"] == BasicClient.data)
 
     @pytest.mark.skipif(pytest.IS_WINDOWS, reason="To fix")
-    async def test_tcp_server_roundtrip(self):
+    async def test_async_tcp_server_roundtrip(self):
         """Test sending and receiving data on tcp socket"""
-        data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"  # unit 1, read register
         expected_response = b'\x01\x00\x00\x00\x00\x05\x01\x03\x02\x00\x11'
+        BasicClient.data = TEST_DATA  # unit 1, read register
+
         # value of 17 as per context
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-        await server.serving
-        random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-        connected, done = self.loop.create_future(), self.loop.create_future()
-        received_value = None
-
-        class BasicClient(asyncio.BaseProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                """Get Connection made."""
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                self.transport.write(data)
-                connected.set_result(True)
-
-            def data_received(self, data):  # pylint: disable=no-self-use
-                """Get Data received."""
-                nonlocal received_value, done
-                received_value = data
-                done.set_result(True)
-
-            def eof_received(self):
-                """EOF received."""
-
-        transport, _ = await self.loop.create_connection(BasicClient,
-                                                         host='127.0.0.1', port=random_port)
-        await asyncio.wait_for(done, timeout=0.1)
-
-        self.assertEqual(received_value, expected_response)
-
-        transport.close()
-        await asyncio.sleep(0)
-        server.server_close()
+        await self.start_server()
+        await self.connect_server()
+        await asyncio.wait_for(BasicClient.done, timeout=0.1)
+        self.assertEqual(BasicClient.received_data, expected_response)
 
     @pytest.mark.skipif(pytest.IS_WINDOWS, reason="To fix")
-    async def test_tcp_server_connection_lost(self):
+    async def test_async_tcp_server_connection_lost(self):
         """Test tcp stream interruption"""
-        server = await StartTcpServer(context=self.context,
-                                      address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-        await server.serving
-        random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-        step1 = self.loop.create_future()
-        time.sleep(1)
-
-        class BasicClient(asyncio.BaseProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                """Get Connection made."""
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                step1.set_result(True)
-
-        _, protocol = await self.loop.create_connection(BasicClient,
-                                                        host='127.0.0.1', port=random_port)
-        await step1
+        await self.start_server()
+        await self.connect_server()
         # On Windows we seem to need to give this an extra chance to finish,
         # otherwise there ends up being an active connection at the assert.
         await asyncio.sleep(0.2)
-        self.assertEqual(len(server.active_connections), 1)
+        self.assertEqual(len(self.server.active_connections), 1)
 
-        protocol.transport.close()
+        BasicClient.protocol.transport.close()
         # close isn't synchronous and there's no
         # notification that it's done
         await asyncio.sleep(0.2)  # so we have to wait a bit
-        self.assertFalse(server.active_connections)
+        self.assertFalse(self.server.active_connections)
+        BasicClient.protocol = None
+        BasicClient.transport = None
 
-        server.server_close()
-
-    async def test_tcp_server_close_active_connection(self):
+    async def test_async_tcp_server_close_active_connection(self):
         """Test server_close() while there are active TCP connections"""
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-
-        await server.serving
-
-        random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-
-        step1 = self.loop.create_future()
-        self.loop.create_future()
-
-        class BasicClient(asyncio.BaseProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                """Get Connection made."""
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                step1.set_result(True)
-
-        await self.loop.create_connection(BasicClient, host='127.0.0.1', port=random_port)
-        await step1
+        await self.start_server()
+        await self.connect_server()
 
         # On Windows we seem to need to give this an extra chance to finish,
         # otherwise there ends up being an active connection at the assert.
         await asyncio.sleep(0.5)
-        server.server_close()
+        self.server.server_close()
 
-        # close isn't synchronous and there's no notification that it's done
-        # so we have to wait a bit
-        await asyncio.sleep(0.5)
-        self.assertTrue(not server.active_connections)
-
-    async def test_tcp_server_no_slave(self):
+    async def test_async_tcp_server_no_slave(self):
         """Test unknown slave unit exception"""
-        context = ModbusServerContext(slaves={0x01: self.store, 0x02: self.store}, single=False)
-        data = b"\x01\x00\x00\x00\x00\x06\x05\x03\x00\x00\x00\x01"
+        self.context = ModbusServerContext(slaves={0x01: self.store, 0x02: self.store}, single=False)
+        BasicClient.data = b"\x01\x00\x00\x00\x00\x06\x05\x03\x00\x00\x00\x01"
+
         # get slave 5 function 3 (holding register)
-        server = await StartTcpServer(context=context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-        await server.serving
-        random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-        connect = self.loop.create_future()
-        receive = self.loop.create_future()
-        eof = self.loop.create_future()
+        await self.start_server()
+        await self.connect_server()
+        self.assertFalse(BasicClient.eof.done())
+        self.server.server_close()
+        self.server = None
 
-        class BasicClient(asyncio.BaseProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                """Get Connection made."""
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                transport.write(data)
-                connect.set_result(True)
-                _logger.debug("Client connected")
-
-            def data_received(self, data):  # NOSONAR pylint: disable=no-self-use,unused-argument
-                """Get Data received."""
-                receive.set_result(True)
-                _logger.debug("Client received data")
-
-            def eof_received(self):  # pylint: disable=no-self-use
-                """Get EOF received."""
-                eof.set_result(True)
-                _logger.debug("Client stream eof")
-
-        await self.loop.create_connection(BasicClient, host='127.0.0.1', port=random_port)
-        await asyncio.wait_for(connect, timeout=0.1)
-        self.assertFalse(eof.done())
-        server.server_close()
-
-    async def test_tcp_server_modbus_error(self):
+    async def test_async_tcp_server_modbus_error(self):
         """Test sending garbage data on a TCP socket should drop the connection"""
-        data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"
-        # get slave 5 function 3 (holding register)
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
+        BasicClient.data = TEST_DATA
 
-        await server.serving
+        # get slave 5 function 3 (holding register)
+        await self.start_server()
         with patch("pymodbus.register_read_message.ReadHoldingRegistersRequest.execute",
                    side_effect=NoSuchSlaveException):
-            connect, receive, eof = self.loop.create_future(),\
-                self.loop.create_future(), self.loop.create_future()
-            random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-
-            class BasicClient(asyncio.BaseProtocol):
-                """Basic client."""
-
-                def connection_made(self, transport):
-                    """Get connection made."""
-                    _logger.debug("Client connected")
-                    self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                    transport.write(data)
-                    connect.set_result(True)
-
-                def data_received(self, data):  # NOSONAR pylint: disable=no-self-use,unused-argument
-                    """Get data received."""
-                    _logger.debug("Client received data")
-                    receive.set_result(True)
-
-                def eof_received(self):  # pylint: disable=no-self-use
-                    """EOF received."""
-                    _logger.debug("Client stream eof")
-                    eof.set_result(True)
-
-            transport, _ = await self.loop.create_connection(BasicClient,
-                                                             host='127.0.0.1', port=random_port)
-            await asyncio.wait_for(connect, timeout=0.1)
-            await asyncio.wait_for(receive, timeout=0.1)
-            self.assertFalse(eof.done())
-            transport.close()
-            server.server_close()
-
-    async def test_tcp_server_internal_exception(self):
-        """Test sending garbage data on a TCP socket should drop the connection"""
-        data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"
-        # get slave 5 function 3 (holding register)
-        server = await StartTcpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
-
-        await server.serving
-        with patch("pymodbus.register_read_message.ReadHoldingRegistersRequest.execute",
-                   side_effect=Exception):
-            connect, receive, eof = self.loop.create_future(),\
-                self.loop.create_future(), self.loop.create_future()
-            random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-
-            class BasicClient(asyncio.BaseProtocol):
-                """Basic client."""
-
-                def connection_made(self, transport):
-                    """Get connection made."""
-                    _logger.debug("Client connected")
-                    self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                    transport.write(data)
-                    connect.set_result(True)
-
-                def data_received(self, data):  # NOSONAR pylint: disable=no-self-use,unused-argument
-                    """Get data received."""
-                    _logger.debug("Client received data")
-                    receive.set_result(True)
-
-                def eof_received(self):  # pylint: disable=no-self-use
-                    """EOF received."""
-                    _logger.debug("Client stream eof")
-                    eof.set_result(True)
-
-            transport, _ = await self.loop.create_connection(BasicClient,
-                                                             host='127.0.0.1', port=random_port)
-            await asyncio.wait_for(connect, timeout=0.1)
-            await asyncio.wait_for(receive, timeout=0.1)
-            self.assertFalse(eof.done())
-            transport.close()
-            server.server_close()
+            await self.connect_server()
+            await asyncio.wait_for(BasicClient.done, timeout=0.1)
 
     # -----------------------------------------------------------------------#
     # Test ModbusTlsProtocol
-
     # -----------------------------------------------------------------------#
-    async def test_start_tls_server(self):
+    async def test_async_start_tls_server_no_loop(self):
         """Test that the modbus tls asyncio server starts correctly"""
         with patch.object(ssl.SSLContext, 'load_cert_chain'):
-            identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-            self.loop = asynctest.Mock(self.loop)  # pylint: disable=attribute-defined-outside-init
-            server = await StartTlsServer(context=self.context, loop=self.loop, identity=identity)
-            self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-            self.assertTrue(server.sslctx is not None)
-            self.loop.create_server.assert_called_once()
+            await self.start_server(do_tls=True, do_ident=True)
+            self.assertEqual(self.server.control.Identity.VendorName, 'VendorName')
+            self.assertTrue(self.server.sslctx is not None)
 
-    async def test_tls_server_serve_forever(self):
+    async def test_async_start_tls_server(self):
+        """Test that the modbus tls asyncio server starts correctly"""
+        with patch.object(ssl.SSLContext, 'load_cert_chain'):
+            await self.start_server(do_tls=True, do_ident=True)
+            self.assertEqual(self.server.control.Identity.VendorName, 'VendorName')
+            self.assertTrue(self.server.sslctx is not None)
+
+    async def test_async_tls_server_serve_forever(self):
         """Test StartTcpServer serve_forever() method"""
         with patch('asyncio.base_events.Server.serve_forever',
-                   new_callable=asynctest.CoroutineMock) as serve:
+                   new_callable=AsyncMock) as serve:
             with patch.object(ssl.SSLContext, 'load_cert_chain'):
-                server = await StartTlsServer(context=self.context,
-                                              address=("127.0.0.1", 0), loop=self.loop)
-                await server.serve_forever()
+                await self.start_server(do_tls=True, do_forever=False)
+                await self.server.serve_forever()
                 serve.assert_awaited()
 
-    async def test_tls_server_serve_forever_twice(self):
+    async def test_async_tls_server_serve_forever_twice(self):
         """Call on serve_forever() twice should result in a runtime error"""
         with patch.object(ssl.SSLContext, 'load_cert_chain'):
-            server = await StartTlsServer(context=self.context,
-                                          address=("127.0.0.1", 0), loop=self.loop)
-            asyncio.create_task(server.serve_forever())
-            await server.serving
+            await self.start_server(do_tls=True)
             with pytest.raises(RuntimeError):
-                await server.serve_forever()
-            server.server_close()
+                await self.server.serve_forever()
 
     # -----------------------------------------------------------------------#
     # Test ModbusUdpProtocol
     # -----------------------------------------------------------------------#
 
-    async def test_start_udp_server(self):
+    async def test_async_start_udp_server_no_loop(self):
         """Test that the modbus udp asyncio server starts correctly"""
-        identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-        self.loop = asynctest.Mock(self.loop)  # pylint: disable=attribute-defined-outside-init
-        server = await StartUdpServer(context=self.context, loop=self.loop, identity=identity)
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR,
+                                      loop=self.loop, identity=self.identity)
         self.assertEqual(server.control.Identity.VendorName, 'VendorName')
-        self.loop.create_datagram_endpoint.assert_called_once()
+        self.assertIsNone(server.protocol)
 
-    async def test_udp_server_serve_forever_start(self):
+    async def test_async_start_udp_server(self):
+        """Test that the modbus udp asyncio server starts correctly"""
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR,
+                                      loop=self.loop, identity=self.identity)
+        asyncio.create_task(server.serve_forever())
+        await server.serving
+        self.assertEqual(server.control.Identity.VendorName, 'VendorName')
+        self.assertFalse(server.protocol is None)
+        server.server_close()
+
+    async def test_async_udp_server_serve_forever_start(self):
         """Test StartUdpServer serve_forever() method"""
         with patch('asyncio.base_events.Server.serve_forever',
-                   new_callable=asynctest.CoroutineMock) as serve:
+                   new_callable=AsyncMock) as serve:
             server = await StartTcpServer(context=self.context,
-                                          address=("127.0.0.1", 0), loop=self.loop)
+                                          address=SERV_ADDR, loop=self.loop)
             await server.serve_forever()
             serve.assert_awaited()
+        server.server_close()
 
-    async def test_udp_server_serve_forever_close(self):
+    async def test_async_udp_server_serve_forever_close(self):
         """Test StartUdpServer serve_forever() method"""
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR, loop=self.loop)
         asyncio.create_task(server.serve_forever())
-
         await server.serving
 
         self.assertTrue(asyncio.isfuture(server.on_connection_terminated))
@@ -415,202 +358,121 @@ class AsyncioServerTest(asynctest.TestCase):  # pylint: disable=too-many-public-
         server.server_close()
         self.assertTrue(server.protocol.is_closing())
 
-    async def test_udp_server_serve_forever_twice(self):
+    async def test_async_udp_server_serve_forever_twice(self):
         """Call on serve_forever() twice should result in a runtime error"""
-        identity = ModbusDeviceIdentification(info={0x00: 'VendorName'})
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0),
-                                      loop=self.loop, identity=identity)
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR,
+                                      loop=self.loop, identity=self.identity)
         asyncio.create_task(server.serve_forever())
         await server.serving
         with self.assertRaises(RuntimeError):
             await server.serve_forever()
         server.server_close()
 
-    async def test_udp_server_receive_data(self):
+    async def test_async_udp_server_receive_data(self):
         """Test that the sending data on datagram socket gets data pushed to framer"""
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR, loop=self.loop)
+        task = asyncio.create_task(server.serve_forever())
         await server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',
                    new_callable=Mock) as process:
-            server.endpoint.datagram_received(data=b"12345", addr=("127.0.0.1", 12345))
+            server.endpoint.datagram_received(data=b"12345", addr=(SERV_IP, 12345))
             await asyncio.sleep(0.1)
             process.seal()
             process.assert_called_once()
             self.assertTrue(process.call_args[1]["data"] == b"12345")
+        server.server_close()
+        await asyncio.sleep(0.1)
+        task.cancel()
 
-            server.server_close()
-
-    async def test_udp_server_send_data(self):
+    async def test_async_udp_server_send_data(self):
         """Test that the modbus udp asyncio server correctly sends data outbound"""
         ModbusDeviceIdentification(info={0x00: 'VendorName'})
-        data = b'x\01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0))
-        asyncio.create_task(server.serve_forever())
-
+        BasicClient.dataTo = b'x\01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x19'
+        BasicClient.done = self.loop.create_future()
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR)
+        task = asyncio.create_task(server.serve_forever())
         await server.serving
         random_port = server.protocol._sock.getsockname()[1]  # pylint: disable=protected-access
         received = server.endpoint.datagram_received = Mock(wraps=server.endpoint.datagram_received)
-        done = self.loop.create_future()
-        received_value = None
-
-        class BasicClient(asyncio.DatagramProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                self.transport.sendto(data)
-
-            def datagram_received(self, data, addr):
-                nonlocal received_value, done
-                print("received")
-                received_value = data
-                done.set_result(True)
-                self.transport.close()
-
         await self.loop.create_datagram_endpoint(BasicClient,
                                                  remote_addr=('127.0.0.1', random_port))
-
         await asyncio.sleep(0.1)
-
         received.assert_called_once()
-        self.assertEqual(received.call_args[0][0], data)
-
+        self.assertEqual(received.call_args[0][0], BasicClient.dataTo)
         server.server_close()
-
         self.assertTrue(server.protocol.is_closing())
-        await asyncio.sleep(0.1)
+        task.cancel()
 
-    async def test_udp_server_roundtrip(self):
+    async def test_async_udp_server_roundtrip(self):
         """Test sending and receiving data on udp socket"""
-        data = b"\x01\x00\x00\x00\x00\x06\x01\x03\x00\x00\x00\x01"  # unit 1, read register
         expected_response = b'\x01\x00\x00\x00\x00\x05'\
                             b'\x01\x03\x02\x00\x11'  # value of 17 as per context
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
+        BasicClient.dataTo = TEST_DATA  # unit 1, read register
+        BasicClient.done = self.loop.create_future()
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR, loop=self.loop)
         asyncio.create_task(server.serve_forever())
-
         await server.serving
-
         random_port = server.protocol._sock.getsockname()[1]  # pylint: disable=protected-access
-
-        _, done = self.loop.create_future(), self.loop.create_future()
-        received_value = None
-
-        class BasicClient(asyncio.DatagramProtocol):
-            """Basic client."""
-
-            def connection_made(self, transport):
-                self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                self.transport.sendto(data)
-
-            def datagram_received(self, data, addr):
-                nonlocal received_value, done
-                print("received")
-                received_value = data
-                done.set_result(True)
-
         transport, _ = await self.loop.create_datagram_endpoint(BasicClient,
                                                                 remote_addr=('127.0.0.1', random_port))
-        await asyncio.wait_for(done, timeout=0.1)
-
-        self.assertEqual(received_value, expected_response)
-
+        await asyncio.wait_for(BasicClient.done, timeout=0.1)
+        self.assertEqual(BasicClient.received_data, expected_response)
         transport.close()
         await asyncio.sleep(0)
         server.server_close()
 
-    async def test_udp_server_exception(self):
+    async def test_async_udp_server_exception(self):
         """Test sending garbage data on a TCP socket should drop the connection"""
-        garbage = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
-        server = await StartUdpServer(context=self.context, address=("127.0.0.1", 0), loop=self.loop)
+        BasicClient.dataTo = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
+        BasicClient.connected = self.loop.create_future()
+        BasicClient.done = self.loop.create_future()
+        server = await StartUdpServer(context=self.context, address=SERV_ADDR, loop=self.loop)
         asyncio.create_task(server.serve_forever())
-
         await server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',
                    new_callable=lambda: Mock(side_effect=Exception)):
-            connect, receive, _ = self.loop.create_future(),\
-                self.loop.create_future(), self.loop.create_future()
             # get the random server port pylint: disable=protected-access
             random_port = server.protocol._sock.getsockname()[1]
-
-            class BasicClient(asyncio.DatagramProtocol):
-                """Basic client."""
-
-                def connection_made(self, transport):
-                    _logger.debug("Client connected")
-                    self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                    transport.sendto(garbage)
-                    connect.set_result(True)
-
-                def datagram_received(self, data, addr):
-                    nonlocal receive
-                    _logger.debug("Client received data")
-                    receive.set_result(True)
-
             _, _ = await self.loop.create_datagram_endpoint(BasicClient,
                                                             remote_addr=('127.0.0.1', random_port))
-            await asyncio.wait_for(connect, timeout=0.1)
-            self.assertFalse(receive.done())
+            await asyncio.wait_for(BasicClient.connected, timeout=0.1)
+            self.assertFalse(BasicClient.done.done())
             self.assertFalse(server.protocol._sock._closed)  # pylint: disable=protected-access
-
-            server.server_close()
+        server.server_close()
+        await asyncio.sleep(0.1)
 
     # -----------------------------------------------------------------------#
     # Test ModbusServerFactory
     # -----------------------------------------------------------------------#
-    def test_modbus_server_factory(self):  # pylint: disable=no-self-use
+
+    def test_async_modbus_server_factory(self):  # pylint: disable=no-self-use
         """Test the base class for all the clients"""
-        with pytest.warns(DeprecationWarning):
-            ModbusServerFactory(store=None)
+        ModbusServerFactory(store=None)
 
-    def test_stop_server(self):  # pylint: disable=no-self-use
+    def test_async_stop_server(self):  # pylint: disable=no-self-use
         """Test stop server."""
-        with pytest.warns(DeprecationWarning):
-            StopServer()
+        StopServer()
 
-    async def test_tcp_server_exception(self):
-        """Sending garbage data on a TCP socket should drop the connection"""
-        garbage = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
+    @pytest.mark.skipif(pytest.IS_WINDOWS, reason="To fix")
+    async def test_async_tcp_server_exception(self):
+        """Send garbage data on a TCP socket should drop the connection"""
+        BasicClient.data = b'\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF'
+        BasicClient.connected = self.loop.create_future()
+        BasicClient.done = self.loop.create_future()
+        BasicClient.eof = self.loop.create_future()
         server = await StartTcpServer(context=self.context,
-                                      address=("127.0.0.1", 0), loop=self.loop)
-        asyncio.create_task(server.serve_forever())
+                                      address=SERV_ADDR, loop=self.loop)
+        task = asyncio.create_task(server.serve_forever())
         await server.serving
         with patch('pymodbus.transaction.ModbusSocketFramer.processIncomingPacket',
                    new_callable=lambda: Mock(side_effect=Exception)):
-            connect, receive, eof = self.loop.create_future(),\
-                self.loop.create_future(), self.loop.create_future()
             random_port = server.server.sockets[0].getsockname()[1]  # get the random server port
-
-            class BasicClient(asyncio.BaseProtocol):
-                """Basic client."""
-
-                def connection_made(self, transport):
-                    """Get connection made."""
-                    _logger.debug("Client connected")
-                    self.transport = transport  # pylint: disable=attribute-defined-outside-init
-                    transport.write(garbage)
-                    connect.set_result(True)
-
-                def data_received(self, data):  # NOSONAR pylint: disable=no-self-use,unused-argument
-                    """Get data received."""
-                    _logger.debug("Client received data")
-                    receive.set_result(True)
-
-                def eof_received(self):  # pylint: disable=no-self-use
-                    """Eof received."""
-                    _logger.debug("Client stream eof")
-                    eof.set_result(True)
-
             _, _ = await self.loop.create_connection(BasicClient, host='127.0.0.1',
                                                      port=random_port)
-            await asyncio.wait_for(connect, timeout=0.1)
-            await asyncio.wait_for(eof, timeout=0.1)
+            await asyncio.wait_for(BasicClient.connected, timeout=0.1)
+            await asyncio.wait_for(BasicClient.eof, timeout=0.1)
             # neither of these should timeout if the test is successful
-            server.server_close()
-
-
-# --------------------------------------------------------------------------- #
-# Main
-# --------------------------------------------------------------------------- #
-if __name__ == "__main__":
-    asynctest.main()
+        server.server_close()
+        await asyncio.sleep(0.1)
+        task.cancel()
+        self.assertTrue(task.cancelled())

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py{38,39,310,py38}
 [testenv]
 deps = -r requirements.txt
 commands =
-    pytest {posargs:--cov=pymodbus/ --cov-report=term-missing --cov-report=xml}
+    pytest {posargs:--cov=pymodbus/ --cov-report=term-missing --cov-report=xml -v --full-trace}
 passenv =
     INCLUDE
     LIB


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
In order to avoid the python error "object not awaited", create_server is moved from __init__ to serve_forever.

Earlier the code looked like:
´´´
startTcpServer()
      with factory = create_server()
....unpredictable application code...
create_task(serve_forever())
     with await factory
´´´
Without any guarantee that serve_forever() would be called.

Now the code will look like:
´´´
startTcpServer()
....unpredictable application code...
create_task(serve_forever())
      with factory = await create_server()
´´´
and thus no error is possible, due to bad application code.
