### PR TITLE
Fix parameter documentation of methods.

### DIFF
--- a/doc/api/doxygen/build.py
+++ b/doc/api/doxygen/build.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc
 """Doxygen API Builder."""
 import os
 import shutil

--- a/examples/common/callback_server.py
+++ b/examples/common/callback_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc
 """Pymodbus Server With Callbacks.
 
 This is an example of adding callbacks to a running modbus server

--- a/examples/common/custom_datablock.py
+++ b/examples/common/custom_datablock.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc
 """Pymodbus Server With Custom Datablock Side Effect.
 
 This is an example of performing custom logic after a value has been

--- a/examples/common/custom_message.py
+++ b/examples/common/custom_message.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc
 """Pymodbus Synchronous Client Examples.
 
 The following is an example of how to use the synchronous modbus client

--- a/examples/common/custom_synchronous_server.py
+++ b/examples/common/custom_synchronous_server.py
@@ -60,8 +60,6 @@ import logging
 # --------------------------------------------------------------------------- #
 # import the various server implementations
 # --------------------------------------------------------------------------- #
-from custom_message import CustomModbusRequest
-
 from pymodbus.version import version
 from pymodbus.server.sync import StartTcpServer
 from pymodbus.device import ModbusDeviceIdentification
@@ -70,6 +68,7 @@ from pymodbus.datastore import (
     ModbusSlaveContext,
     ModbusServerContext,
 )
+from .custom_message import CustomModbusRequest  # pylint: disable=relative-beyond-top-level
 
 # --------------------------------------------------------------------------- #
 # configure the service logging

--- a/examples/common/dbstore_update_server.py
+++ b/examples/common/dbstore_update_server.py
@@ -1,3 +1,4 @@
+# pylint: disable=differing-param-doc,missing-any-param-doc
 """Pymodbus Server With Updating Thread.
 
 This is an example of having a background thread updating the

--- a/examples/common/performance.py
+++ b/examples/common/performance.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc
 """Pymodbus Performance Example.
 
 The following is an quick performance check of the synchronous
@@ -52,8 +53,8 @@ host = "127.0.0.1"  # pylint: disable=invalid-name
 def single_client_test(n_host, n_cycles):
     """Perform a single threaded test of a synchronous client against the specified host
 
-    :param host: The host to connect to
-    :param cycles: The number of iterations to perform
+    :param n_host: The host to connect to
+    :param n_cycles: The number of iterations to perform
     """
     logger = log_to_stderr()
     logger.setLevel(logging.WARNING)

--- a/examples/common/updating_server.py
+++ b/examples/common/updating_server.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-any-param-doc,differing-param-doc
 """Pymodbus Server With Updating Thread.
 
 This is an example of having a background thread updating the

--- a/examples/contrib/bcd_payload.py
+++ b/examples/contrib/bcd_payload.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc,missing-raises-doc,missing-any-param-doc
 """Modbus BCD Payload Builder.
 
 This is an example of building a custom payload builder

--- a/examples/contrib/concurrent_client.py
+++ b/examples/contrib/concurrent_client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc
 """Concurrent Modbus Client.
 
 This is an example of writing a high performance modbus client that allows

--- a/examples/contrib/libmodbus_client.py
+++ b/examples/contrib/libmodbus_client.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc,missing-raises-doc
 """Libmodbus Protocol Wrapper.
 
 What follows is an example wrapper of the libmodbus library

--- a/examples/contrib/message_generator.py
+++ b/examples/contrib/message_generator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc
 """Modbus Message Generator.
 
 The following is an example of how to generate example encoded messages

--- a/examples/contrib/message_parser.py
+++ b/examples/contrib/message_parser.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc,missing-any-param-doc
 """Modbus Message Parser.
 
 The following is an example of how to parse modbus messages
@@ -105,7 +106,7 @@ class Decoder:
                         "  %-12s => %s" % (k_item, v_item)  # pylint: disable=consider-using-f-string
                     )
 
-            elif isinstance(v_dict, collections.Iterable):
+            elif isinstance(v_dict, collections.Iterable):  # pylint: disable=no-member
                 print("%-15s =" % k_dict)  # pylint: disable=consider-using-f-string
                 value = str([int(x) for x in v_dict])
                 for line in textwrap.wrap(value, 60):

--- a/examples/contrib/modbus_mapper.py
+++ b/examples/contrib/modbus_mapper.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-type-doc,differing-param-doc
 r"""This is used to generate decoder blocks.
 
 so that non-programmers can define the

--- a/examples/contrib/modbus_simulator.py
+++ b/examples/contrib/modbus_simulator.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# pylint: disable=missing-raises-doc
 """An example of creating a fully implemented modbus server.
 
 with read/write data as well as user configurable base data

--- a/examples/contrib/modicon_payload.py
+++ b/examples/contrib/modicon_payload.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-type-doc,missing-raises-doc
 """Modbus Modicon Payload Builder.
 
 This is an example of building a custom payload builder

--- a/examples/contrib/remote_server_context.py
+++ b/examples/contrib/remote_server_context.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-type-doc,missing-param-doc,differing-param-doc,missing-raises-doc
 """Although there is a remote server context already in the main library,
 
 it works under the assumption that users would have a server context

--- a/examples/contrib/thread_safe_datastore.py
+++ b/examples/contrib/thread_safe_datastore.py
@@ -1,3 +1,4 @@
+# pylint: disable=missing-type-doc
 """Thread safe datastore."""
 import threading
 from contextlib import contextmanager

--- a/pymodbus/bit_read_message.py
+++ b/pymodbus/bit_read_message.py
@@ -1,4 +1,5 @@
 """Bit Reading Request/Response messages."""
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.pdu import ModbusRequest
 from pymodbus.pdu import ModbusResponse

--- a/pymodbus/bit_write_message.py
+++ b/pymodbus/bit_write_message.py
@@ -2,6 +2,7 @@
 
 TODO write mask request/response
 """
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.constants import ModbusStatus
 from pymodbus.pdu import ModbusRequest

--- a/pymodbus/client/asynchronous/async_io/__init__.py
+++ b/pymodbus/client/asynchronous/async_io/__init__.py
@@ -1,4 +1,5 @@
 """Asynchronous framework adapter for asyncio."""
+# pylint: disable=missing-type-doc
 import logging
 import socket
 import asyncio
@@ -45,7 +46,6 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         The transport argument is the transport representing the connection.
 
         :param transport:
-        :return:
         """
         self.transport = transport
         self._connection_made()
@@ -59,7 +59,6 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         The argument is either an exception object or None
 
         :param reason:
-        :return:
         """
         self.transport = None
         self._connection_lost(reason)
@@ -73,15 +72,11 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         data is a non-empty bytes object containing the incoming data.
 
         :param data:
-        :return:
         """
         self._data_received(data)
 
     def create_future(self):  # pylint: disable=no-self-use
-        """Help function to create asyncio Future object.
-
-        :return:
-        """
+        """Help function to create asyncio Future object."""
         return asyncio.Future()
 
     def resolve_future(self, my_future, result):  # pylint: disable=no-self-use
@@ -89,7 +84,6 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
 
         :param my_future:
         :param result:
-        :return:
         """
         if not my_future.done():
             my_future.set_result(result)
@@ -99,7 +93,6 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
 
         :param my_future:
         :param exc:
-        :return:
         """
         if not my_future.done():
             my_future.set_exception(exc)
@@ -155,6 +148,7 @@ class BaseModbusAsyncClientProtocol(AsyncModbusClientMixin):
         """Handle the processed response and link to correct deferred
 
         :param reply: The reply to process
+        :param kwargs: The rest
         """
         if reply is not None:
             tid = reply.transaction_id
@@ -196,7 +190,6 @@ class ModbusClientProtocol(BaseModbusAsyncClientProtocol, asyncio.Protocol):
         data is a non-empty bytes object containing the incoming data.
 
         :param data:
-        :return:
         """
         self._data_received(data)
 
@@ -270,10 +263,7 @@ class ReconnectingAsyncioModbusTcpClient:
         return await self._connect()
 
     def stop(self):
-        """Stop client.
-
-        :return:
-        """
+        """Stop client."""
         # prevent reconnect:
         self.host = None
 
@@ -642,10 +632,7 @@ class AsyncioModbusUdpClient:
         self._proto_args = kwargs
 
     def stop(self):
-        """Stop connection.
-
-        :return:
-        """
+        """Stop connection."""
         # prevent reconnect:
         # self.host = None
 
@@ -771,10 +758,7 @@ class AsyncioModbusSerialClient:
         return self._connected_event.is_set()
 
     async def connect(self):
-        """Connect Async client.
-
-        :return:
-        """
+        """Connect Async client."""
         _logger.debug(TEXT_CONNECTING)
         try:
             await create_serial_connection(

--- a/pymodbus/client/asynchronous/deprecated/asynchronous.py
+++ b/pymodbus/client/asynchronous/deprecated/asynchronous.py
@@ -30,6 +30,7 @@ Another example::
        reactor.callLater(1, process)
        reactor.run()
 """
+# pylint: disable=missing-type-doc,differing-param-doc,missing-param-doc
 import logging
 from twisted.internet import defer, protocol
 from twisted.python.failure import Failure

--- a/pymodbus/client/asynchronous/factory/serial.py
+++ b/pymodbus/client/asynchronous/factory/serial.py
@@ -1,4 +1,5 @@
 """Factory to create asynchronous serial clients based on twisted/tornado/asyncio."""
+# pylint: disable=missing-type-doc
 import logging
 import asyncio
 
@@ -122,6 +123,7 @@ def get_factory(scheduler):
 
     :param scheduler: REACTOR/IO_LOOP/ASYNC_IO
     :return:
+    :raises Exception: Failure
     """
     if scheduler == schedulers.REACTOR:
         return reactor_factory

--- a/pymodbus/client/asynchronous/factory/tcp.py
+++ b/pymodbus/client/asynchronous/factory/tcp.py
@@ -1,4 +1,5 @@
 """Factory to create asynchronous tcp clients based on twisted/tornado/asyncio."""
+# pylint: disable=missing-type-doc
 import logging
 import asyncio
 
@@ -107,9 +108,6 @@ def async_io_factory(host="127.0.0.1", port=Defaults.Port, **kwargs):
 
     :param host: Host IP address
     :param port: Port
-    :param framer: Modbus Framer
-    :param source_address: Bind address
-    :param timeout: Timeout in seconds
     :param kwargs:
     :return: asyncio event loop and tcp client
     """
@@ -141,6 +139,7 @@ def get_factory(scheduler):
 
     :param scheduler: REACTOR/IO_LOOP/ASYNC_IO
     :return: new factory
+    :raises Exception: Failure
     """
     if scheduler == schedulers.REACTOR:
         return reactor_factory

--- a/pymodbus/client/asynchronous/factory/tls.py
+++ b/pymodbus/client/asynchronous/factory/tls.py
@@ -1,4 +1,5 @@
 """Factory to create asynchronous tls clients based on asyncio."""
+# pylint: disable=missing-type-doc
 import logging
 import asyncio
 
@@ -22,12 +23,8 @@ def async_io_factory(
     :param host: Target server"s name, also matched for certificate
     :param port: Port
     :param sslctx: The SSLContext to use for TLS (default None and auto create)
-    :param certfile: The optional client"s cert file path for TLS server request
-    :param keyfile: The optional client"s key file path for TLS server request
-    :param password: The password for for decrypting client"s private key file
+    :param server_hostname: Bind address
     :param framer: Modbus Framer
-    :param source_address: Bind address
-    :param timeout: Timeout in seconds
     :param kwargs:
     :return: asyncio event loop and tcp client
     """
@@ -61,7 +58,8 @@ def get_factory(scheduler):
     """Get protocol factory based on the backend scheduler being used.
 
     :param scheduler: ASYNC_IO
-    :return
+    :return: protocol object
+    :raises Exception: Failure
     """
     if scheduler == schedulers.ASYNC_IO:
         return async_io_factory

--- a/pymodbus/client/asynchronous/factory/udp.py
+++ b/pymodbus/client/asynchronous/factory/udp.py
@@ -1,4 +1,5 @@
 """UDP implementation."""
+# pylint: disable=missing-type-doc
 import logging
 import asyncio
 
@@ -74,9 +75,6 @@ def async_io_factory(host="127.0.0.1", port=Defaults.Port, **kwargs):
 
     :param host: Host IP address
     :param port: Port
-    :param framer: Modbus Framer
-    :param source_address: Bind address
-    :param timeout: Timeout in seconds
     :param kwargs:
     :return: asyncio event loop and udp client
     """
@@ -105,6 +103,7 @@ def get_factory(scheduler):
 
     :param scheduler: REACTOR/IO_LOOP/ASYNC_IO
     :return: new factory
+    :raises Exception: Failure
     """
     if scheduler == schedulers.REACTOR:
         return reactor_factory

--- a/pymodbus/client/asynchronous/serial.py
+++ b/pymodbus/client/asynchronous/serial.py
@@ -26,6 +26,7 @@ class AsyncModbusSerialClient:  # pylint: disable=too-few-public-methods
 
         :method: The serial framer to instantiate
         :returns: The requested serial framer
+        :raises Exception: Failure
         """
         method = method.lower()
         if method == "ascii":

--- a/pymodbus/client/asynchronous/thread.py
+++ b/pymodbus/client/asynchronous/thread.py
@@ -31,26 +31,17 @@ class EventLoopThread:
         self._event_loop.daemon = True
 
     def _start(self):
-        """Start the backend event loop
-
-        :return:
-        """
+        """Start the backend event loop."""
         self._start_loop(*self._args, **self._kwargs)
 
     def start(self):
-        """Start the backend event loop
-
-        :return:
-        """
+        """Start the backend event loop."""
         txt = f'Starting Event Loop: "PyModbus_{self._name}"'
         _logger.info(txt)
         self._event_loop.start()
 
     def stop(self):
-        """Stop the backend event loop
-
-        :return:
-        """
+        """Stop the backend event loop."""
         txt = f'Stopping Event Loop: "PyModbus_{self._name}"'
         _logger.info(txt)
         self._stop_loop()

--- a/pymodbus/client/asynchronous/tornado/__init__.py
+++ b/pymodbus/client/asynchronous/tornado/__init__.py
@@ -1,4 +1,5 @@
 """Asynchronous framework adapter for tornado."""
+# pylint: skip-file
 import logging
 import abc
 import time

--- a/pymodbus/client/asynchronous/twisted/__init__.py
+++ b/pymodbus/client/asynchronous/twisted/__init__.py
@@ -30,6 +30,7 @@ Another example::
        reactor.callLater(1, process)
        reactor.run()
 """
+# pylint: skip-file
 import logging
 
 from twisted.internet import defer, protocol

--- a/pymodbus/client/common.py
+++ b/pymodbus/client/common.py
@@ -4,6 +4,7 @@ This is a common client mixin that can be used by
 both the synchronous and asynchronous clients to
 simplify the interface.
 """
+# pylint: disable=missing-type-doc
 from pymodbus.bit_read_message import (
     ReadCoilsRequest,
     ReadDiscreteInputsRequest,
@@ -50,7 +51,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to read from
         :param count: The number of coils to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = ReadCoilsRequest(address, count, **kwargs)
@@ -61,7 +62,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to read from
         :param count: The number of discretes to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = ReadDiscreteInputsRequest(address, count, **kwargs)
@@ -72,7 +73,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to write to
         :param value: The value to write to the specified address
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = WriteSingleCoilRequest(address, value, **kwargs)
@@ -83,7 +84,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to write to
         :param values: The values to write to the specified address
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = WriteMultipleCoilsRequest(address, values, **kwargs)
@@ -94,7 +95,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to write to
         :param value: The value to write to the specified address
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = WriteSingleRegisterRequest(address, value, **kwargs)
@@ -105,7 +106,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to write to
         :param values: The values to write to the specified address
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = WriteMultipleRegistersRequest(address, values, **kwargs)
@@ -116,7 +117,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to read from
         :param count: The number of registers to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = ReadHoldingRegistersRequest(address, count, **kwargs)
@@ -127,7 +128,7 @@ class ModbusClientMixin:
 
         :param address: The starting address to read from
         :param count: The number of registers to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = ReadInputRegistersRequest(address, count, **kwargs)
@@ -136,11 +137,8 @@ class ModbusClientMixin:
     def readwrite_registers(self, *args, **kwargs):
         """Read/Write registers
 
-        :param read_address: The address to start reading from
-        :param read_count: The number of registers to read from address
-        :param write_address: The address to start writing to
-        :param write_registers: The registers to write to the specified address
-        :param unit: The slave unit this request is targeting
+        :param args:
+        :param kwargs:
         :returns: A deferred response handle
         """
         request = ReadWriteMultipleRegistersRequest(*args, **kwargs)
@@ -149,10 +147,7 @@ class ModbusClientMixin:
     def mask_write_register(self, *args, **kwargs):
         """Mask write register.
 
-        :param address: The address of the register to write
-        :param and_mask: The and bitmask to apply to the register address
-        :param or_mask: The or bitmask to apply to the register address
-        :param unit: The slave unit this request is targeting
+        :args:
         :returns: A deferred response handle
         """
         request = MaskWriteRegisterRequest(*args, **kwargs)

--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -1,4 +1,5 @@
 """Sync client."""
+# pylint: disable=missing-type-doc
 import logging
 import socket
 import select
@@ -56,7 +57,7 @@ class BaseModbusClient(ModbusClientMixin):
     def connect(self):  # pylint: disable=no-self-use
         """Connect to the modbus remote host.
 
-        :returns: True if connection succeeded, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
@@ -66,7 +67,7 @@ class BaseModbusClient(ModbusClientMixin):
     def is_socket_open(self):
         """Check whether the underlying socket/serial is open or not.
 
-        :returns: True if socket/serial is open, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException(
             f"is_socket_open() not implemented by {self.__str__()}"
@@ -83,7 +84,7 @@ class BaseModbusClient(ModbusClientMixin):
         """Send data on the underlying socket.
 
         :param request: The encoded request to send
-        :return: The number of bytes written
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
@@ -95,7 +96,7 @@ class BaseModbusClient(ModbusClientMixin):
         """Read data from the underlying descriptor.
 
         :param size: The number of bytes to read
-        :return: The bytes read
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
@@ -107,6 +108,7 @@ class BaseModbusClient(ModbusClientMixin):
 
         :param request: The request to process
         :returns: The result of the request execution
+        :raises ConnectionException:
         """
         if not self.connect():
             raise ConnectionException(f"Failed to connect[{self.__str__()}]")
@@ -119,6 +121,7 @@ class BaseModbusClient(ModbusClientMixin):
         """Implement the client with enter block.
 
         :returns: The current instance of the client
+        :raises ConnectionException:
         """
         if not self.connect():
             raise ConnectionException(f"Failed to connect[{self.__str__()}]")
@@ -164,7 +167,6 @@ class BaseModbusClient(ModbusClientMixin):
         """Register a function and sub function class with the decoder.
 
         :param function: Custom function class to register
-        :return:
         """
         self.framer.decoder.register(function)
 
@@ -244,6 +246,7 @@ class ModbusTcpClient(BaseModbusClient):
 
         :param request: The encoded request to send
         :return: The number of bytes written
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -262,9 +265,7 @@ class ModbusTcpClient(BaseModbusClient):
         :return: The bytes read if the peer sent a response, or a zero-length
                  response if no data packets were received from the client at
                  all.
-        :raises: ConnectionException if the socket is not initialized, or the
-                 peer either has closed the connection before this method is
-                 invoked or closes it before sending any data before timeout.
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -330,7 +331,7 @@ class ModbusTcpClient(BaseModbusClient):
                until it was determined that the remote closed the
                socket
         :return: The more than zero bytes read from the remote end
-        :raises: ConnectionException If the remote end didn"t send any
+        :raises ConnectionException: If the remote end didn't send any
                  data at all before closing the connection.
         """
         self.close()
@@ -431,6 +432,7 @@ class ModbusTlsClient(ModbusTcpClient):
 
         :param size: The number of bytes to read
         :return: The bytes read
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -551,6 +553,7 @@ class ModbusUdpClient(BaseModbusClient):
 
         :param request: The encoded request to send
         :return: The number of bytes written
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -563,6 +566,7 @@ class ModbusUdpClient(BaseModbusClient):
 
         :param size: The number of bytes to read
         :return: The bytes read
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -651,6 +655,8 @@ class ModbusSerialClient(
 
         :method: The serial framer to instantiate
         :returns: The requested serial framer
+        :raises ConnectionException:
+        :raises ParameterException:
         """
         method = method.lower()
         if method == "ascii":
@@ -714,6 +720,7 @@ class ModbusSerialClient(
 
         :param request: The encoded request to send
         :return: The number of bytes written
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())
@@ -764,6 +771,7 @@ class ModbusSerialClient(
 
         :param size: The number of bytes to read
         :return: The bytes read
+        :raises ConnectionException:
         """
         if not self.socket:
             raise ConnectionException(self.__str__())

--- a/pymodbus/client/tls_helper.py
+++ b/pymodbus/client/tls_helper.py
@@ -1,4 +1,5 @@
 """TLS helper for Modbus TLS Client."""
+# pylint: disable=missing-type-doc
 import ssl
 
 

--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -1,4 +1,5 @@
 """Context for datastore."""
+# pylint: disable=missing-type-doc
 import logging
 
 from pymodbus.exceptions import NoSuchSlaveException
@@ -53,7 +54,7 @@ class ModbusSlaveContext(IModbusSlaveContext):
     def validate(self, fc_as_hex, address, count=1):
         """Validate the request to make sure it is in range.
 
-        :param fx: The function we are working with
+        :param fc_as_hex: The function we are working with
         :param address: The starting address
         :param count: The number of values to test
         :returns: True if the request in within range, False otherwise
@@ -67,7 +68,7 @@ class ModbusSlaveContext(IModbusSlaveContext):
     def getValues(self, fc_as_hex, address, count=1):
         """Get `count` values from datastore.
 
-        :param fx: The function we are working with
+        :param fc_as_hex: The function we are working with
         :param address: The starting address
         :param count: The number of values to retrieve
         :returns: The requested values from a:a+c
@@ -81,7 +82,7 @@ class ModbusSlaveContext(IModbusSlaveContext):
     def setValues(self, fc_as_hex, address, values):
         """Set the datastore with the supplied values.
 
-        :param fx: The function we are working with
+        :param fc_as_hex: The function we are working with
         :param address: The starting address
         :param values: The new values to be set
         """
@@ -94,10 +95,9 @@ class ModbusSlaveContext(IModbusSlaveContext):
     def register(self, function_code, fc_as_hex, datablock=None):
         """Register a datablock with the slave context.
 
-        :param fc: function code (int)
-        :param fx: string representation of function code (e.g "cf" )
+        :param function_code: function code (int)
+        :param fc_as_hex: string representation of function code (e.g "cf" )
         :param datablock: datablock to associate with this function code
-        :return:
         """
         self.store[fc_as_hex] = datablock or ModbusSequentialDataBlock.create()
         self._IModbusSlaveContext__fx_mapper[  # pylint: disable=no-member
@@ -147,6 +147,7 @@ class ModbusServerContext:
 
         :param slave: The slave context to set
         :param context: The new context to set for this slave
+        :raises NoSuchSlaveException:
         """
         if self.single:
             slave = Defaults.UnitId
@@ -159,6 +160,7 @@ class ModbusServerContext:
         """Use to access the slave context.
 
         :param slave: The slave context to remove
+        :raises NoSuchSlaveException:
         """
         if not self.single and (0xF7 >= slave >= 0x00):
             del self._slaves[slave]
@@ -170,6 +172,7 @@ class ModbusServerContext:
 
         :param slave: The slave context to get
         :returns: The requested slave context
+        :raises NoSuchSlaveException:
         """
         if self.single:
             slave = Defaults.UnitId

--- a/pymodbus/datastore/database/redis_datastore.py
+++ b/pymodbus/datastore/database/redis_datastore.py
@@ -1,4 +1,5 @@
 """Datastore using redis."""
+# pylint: disable=missing-type-doc
 import logging
 import redis
 from pymodbus.interfaces import IModbusSlaveContext

--- a/pymodbus/datastore/database/sql_datastore.py
+++ b/pymodbus/datastore/database/sql_datastore.py
@@ -1,4 +1,5 @@
 """Datastore using SQL."""
+# pylint: disable=missing-type-doc
 import logging
 import sqlalchemy
 import sqlalchemy.types as sqltypes
@@ -157,7 +158,7 @@ class SqlSlaveContext(IModbusSlaveContext):
     def _set(self, type, offset, values):  # pylint: disable=redefined-builtin
         """Set.
 
-        :param key: The type prefix to use
+        :param type: The type prefix to use
         :param offset: The address offset to start at
         :param values: The values to set
         """

--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -1,4 +1,5 @@
 """Remote datastore."""
+# pylint: disable=missing-type-doc
 import logging
 
 from pymodbus.exceptions import NotImplementedException

--- a/pymodbus/datastore/store.py
+++ b/pymodbus/datastore/store.py
@@ -44,6 +44,7 @@ or a range read to fail.
 I have both methods implemented, and leave it up to the user to change
 based on their preference.
 """
+# pylint: disable=missing-type-doc
 import logging
 
 from pymodbus.exceptions import NotImplementedException, ParameterException
@@ -94,7 +95,7 @@ class BaseModbusDataBlock:
 
         :param address: The starting address
         :param count: The number of values to test for
-        :returns: True if the request in within range, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Datastore Address Check")
 
@@ -105,7 +106,7 @@ class BaseModbusDataBlock:
 
         :param address: The starting address
         :param count: The number of values to retrieve
-        :returns: The requested values from a:a+c
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Datastore Value Retrieve")
 
@@ -116,6 +117,7 @@ class BaseModbusDataBlock:
 
         :param address: The starting address
         :param values: The values to store
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Datastore Value Retrieve")
 
@@ -302,6 +304,7 @@ class ModbusSparseDataBlock(BaseModbusDataBlock):
         :param address: The starting address
         :param values: The new values to be set
         :param use_as_default: Use the values as default
+        :raises ParameterException:
         """
         if isinstance(values, dict):
             new_offsets = list(

--- a/pymodbus/device.py
+++ b/pymodbus/device.py
@@ -4,6 +4,7 @@ These are the device management handlers.  They should be
 maintained in the server context and the various methods
 should be inserted in the correct locations.
 """
+# pylint: disable=missing-type-doc
 from collections import OrderedDict
 import struct
 

--- a/pymodbus/diag_message.py
+++ b/pymodbus/diag_message.py
@@ -3,6 +3,7 @@
 These need to be tied into a the current server context
 or linked to the appropriate data
 """
+# pylint: disable=missing-type-doc
 import struct
 
 from pymodbus.constants import ModbusStatus, ModbusPlusOperation

--- a/pymodbus/events.py
+++ b/pymodbus/events.py
@@ -4,6 +4,7 @@ An event byte returned by the Get Communications Event Log function
 can be any one of four types. The type is defined by bit 7
 (the high-order bit) in each byte. It may be further defined by bit 6.
 """
+# pylint: disable=missing-type-doc
 from pymodbus.exceptions import NotImplementedException
 from pymodbus.exceptions import ParameterException
 from pymodbus.utilities import pack_bitstring, unpack_bitstring
@@ -15,7 +16,7 @@ class ModbusEvent:
     def encode(self):  # pylint: disable=no-self-use
         """Encode the status bits to an event message.
 
-        :returns: The encoded event message
+        :raises NotImplementedException:
         """
         raise NotImplementedException()
 
@@ -23,6 +24,7 @@ class ModbusEvent:
         """Decode the event message to its status bits.
 
         :param event: The event to decode
+        :raises NotImplementedException:
         """
         raise NotImplementedException()
 
@@ -159,6 +161,7 @@ class EnteredListenModeEvent(ModbusEvent):
         """Decode the event message to its status bits.
 
         :param event: The event to decode
+        :raises ParameterException:
         """
         if event != self.__encoded:
             raise ParameterException("Invalid decoded value")
@@ -195,6 +198,7 @@ class CommunicationRestartEvent(ModbusEvent):
         """Decode the event message to its status bits.
 
         :param event: The event to decode
+        :raises ParameterException:
         """
         if event != self.__encoded:
             raise ParameterException("Invalid decoded value")

--- a/pymodbus/factory.py
+++ b/pymodbus/factory.py
@@ -8,6 +8,7 @@ it does help keep things organized).
 Regardless of how many functions are added to the lookup, O(1) behavior is
 kept as a result of a pre-computed lookup dictionary.
 """
+# pylint: disable=missing-type-doc
 import logging
 
 from pymodbus.pdu import IllegalFunctionRequest
@@ -227,7 +228,7 @@ class ServerDecoder(IModbusDecoder):
         """Register a function and sub function class with the decoder.
 
         :param function: Custom function class to register
-        :return:
+        :raises MessageRegisterException:
         """
         if function and not issubclass(function, ModbusRequest):
             raise MessageRegisterException(
@@ -334,6 +335,7 @@ class ClientDecoder(IModbusDecoder):
 
         :param data: The response packet to decode
         :returns: The decoded request or an exception response object
+        :raises ModbusException:
         """
         fc_string = function_code = int(data[0])
         if function_code in self.__lookup:
@@ -368,7 +370,7 @@ class ClientDecoder(IModbusDecoder):
         :param function: Custom function class to register
         :param sub_function: Custom sub function class to register
         :param force: Force update the existing class
-        :return:
+        :raises MessageRegisterException:
         """
         if function and not issubclass(function, ModbusResponse):
             raise MessageRegisterException(

--- a/pymodbus/file_message.py
+++ b/pymodbus/file_message.py
@@ -2,6 +2,7 @@
 
 Currently none of these messages are implemented
 """
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.pdu import ModbusRequest
 from pymodbus.pdu import ModbusResponse

--- a/pymodbus/framer/__init__.py
+++ b/pymodbus/framer/__init__.py
@@ -1,4 +1,5 @@
 """Framer start."""
+# pylint: disable=missing-type-doc
 from pymodbus.interfaces import IModbusFramer
 
 # Unit ID, Function Code

--- a/pymodbus/framer/ascii_framer.py
+++ b/pymodbus/framer/ascii_framer.py
@@ -1,4 +1,5 @@
 """Ascii_framer."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 from binascii import b2a_hex, a2b_hex
@@ -163,8 +164,8 @@ class ModbusAsciiFramer(ModbusFramer):
         :param callback: The function to send results to
         :param unit: Process if unit id matches, ignore otherwise (could be a
                list of unit ids (server) or single unit id(client/server))
-        :param single: True or False (If True, ignore unit address validation)
-
+        :param kwargs:
+        :raises ModbusIOException:
         """
         if not isinstance(unit, (list, tuple)):
             unit = [unit]

--- a/pymodbus/framer/binary_framer.py
+++ b/pymodbus/framer/binary_framer.py
@@ -1,4 +1,5 @@
 """Binary framer."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 from pymodbus.exceptions import ModbusIOException
@@ -158,8 +159,8 @@ class ModbusBinaryFramer(ModbusFramer):
         :param callback: The function to send results to
         :param unit: Process if unit id matches, ignore otherwise (could be a
                list of unit ids (server) or single unit id(client/server)
-        :param single: True or False (If True, ignore unit address validation)
-
+        :param kwargs:
+        :raises ModbusIOException:
         """
         self.addToFrame(data)
         if not isinstance(unit, (list, tuple)):

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -1,4 +1,5 @@
 """RTU framer."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 import time
@@ -216,8 +217,7 @@ class ModbusRtuFramer(ModbusFramer):
         :param callback: The function to send results to
         :param unit: Process if unit id matches, ignore otherwise (could be a
                list of unit ids (server) or single unit id(client/server)
-        :param single: True or False (If True, ignore unit address validation)
-
+        :param kwargs:
         """
         if not isinstance(unit, (list, tuple)):
             unit = [unit]

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -1,4 +1,5 @@
 """Socket framer."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 from pymodbus.exceptions import ModbusIOException
@@ -155,8 +156,7 @@ class ModbusSocketFramer(ModbusFramer):
         :param callback: The function to send results to
         :param unit: Process if unit id matches, ignore otherwise (could be a
                list of unit ids (server) or single unit id(client/server)
-        :param single: True or False (If True, ignore unit address validation)
-        :return:
+        :param kwargs:
         """
         if not isinstance(unit, (list, tuple)):
             unit = [unit]

--- a/pymodbus/framer/tls_framer.py
+++ b/pymodbus/framer/tls_framer.py
@@ -1,4 +1,5 @@
 """TLS framer."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 from pymodbus.exceptions import ModbusIOException
@@ -125,8 +126,7 @@ class ModbusTlsFramer(ModbusFramer):
         :param callback: The function to send results to
         :param unit: Process if unit id matches, ignore otherwise (could be a
                list of unit ids (server) or single unit id(client/server)
-        :param single: True or False (If True, ignore unit address validation)
-        :return:
+        :param kwargs:
         """
         if not isinstance(unit, (list, tuple)):
             unit = [unit]

--- a/pymodbus/interfaces.py
+++ b/pymodbus/interfaces.py
@@ -3,6 +3,7 @@
 A collection of base classes that are used throughout
 the pymodbus library.
 """
+# pylint: disable=missing-type-doc
 from pymodbus.exceptions import NotImplementedException
 
 TEXT_METHOD = "Method not implemented by derived class"
@@ -41,7 +42,7 @@ class IModbusDecoder:
         """Decode a given packet.
 
         :param message: The raw modbus request packet
-        :return: The decoded modbus message or None if error
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -51,7 +52,7 @@ class IModbusDecoder:
         """Use `function_code` to determine the class of the PDU.
 
         :param function_code: The function code specified in a frame.
-        :returns: The class of the PDU that has a matching `function_code`.
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -59,7 +60,7 @@ class IModbusDecoder:
         """Register a function and sub function class with the decoder.
 
         :param function: Custom function class to register
-        :return:
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -76,7 +77,7 @@ class IModbusFramer:
     def checkFrame(self):  # NOSONAR pylint: disable=no-self-use,invalid-name
         """Check and decode the next frame.
 
-        :returns: True if we successful, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -96,6 +97,7 @@ class IModbusFramer:
         data to the buffer handle.
 
         :param message: The most recent packet
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -105,14 +107,14 @@ class IModbusFramer:
         This is meant to be used in a while loop in the decoding phase to let
         the decoder know that there is still data in the buffer.
 
-        :returns: True if ready, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
     def getFrame(self):  # NOSONAR pylint: disable=no-self-use,invalid-name
         """Get the next frame from the buffer.
 
-        :returns: The frame data or ""
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -125,6 +127,7 @@ class IModbusFramer:
         to the result header. This may not be needed for serial messages.
 
         :param result: The response packet
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -144,6 +147,7 @@ class IModbusFramer:
 
         :param data: The new packet data
         :param callback: The function to send results to
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -154,7 +158,7 @@ class IModbusFramer:
         request / response message.
 
         :param message: The request/response to send
-        :returns: The built packet
+        :raises NotImplementedException:
         """
         raise NotImplementedException(TEXT_METHOD)
 
@@ -193,7 +197,7 @@ class IModbusSlaveContext:
         :param fx: The function we are working with
         :param address: The starting address
         :param count: The number of values to test
-        :returns: True if the request in within range, False otherwise
+        :raises NotImplementedException:
         """
         raise NotImplementedException("validate context values")
 
@@ -205,7 +209,7 @@ class IModbusSlaveContext:
         :param fx: The function we are working with
         :param address: The starting address
         :param count: The number of values to retrieve
-        :returns: The requested values from a:a+c
+        :raises NotImplementedException:
         """
         raise NotImplementedException("get context values")
 
@@ -217,6 +221,7 @@ class IModbusSlaveContext:
         :param fx: The function we are working with
         :param address: The starting address
         :param values: The new values to be set
+        :raises NotImplementedException:
         """
         raise NotImplementedException("set context values")
 
@@ -234,7 +239,7 @@ class IPayloadBuilder:  # pylint: disable=too-few-public-methods
         This list is two bytes per element and can
         thus be treated as a list of registers.
 
-        :returns: The payload buffer as a list
+        :raises NotImplementedException:
         """
         raise NotImplementedException("set context values")
 

--- a/pymodbus/mei_message.py
+++ b/pymodbus/mei_message.py
@@ -1,4 +1,5 @@
 """Encapsulated Interface (MEI) Transport Messages."""
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.constants import DeviceInformation, MoreData
 from pymodbus.pdu import ModbusRequest

--- a/pymodbus/other_message.py
+++ b/pymodbus/other_message.py
@@ -2,6 +2,7 @@
 
 Currently not all implemented
 """
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.constants import ModbusStatus
 from pymodbus.pdu import ModbusRequest

--- a/pymodbus/payload.py
+++ b/pymodbus/payload.py
@@ -3,6 +3,7 @@
 A collection of utilities for building and decoding
 modbus messages payloads.
 """
+# pylint: disable=missing-type-doc
 import logging
 
 from struct import pack, unpack
@@ -60,6 +61,7 @@ class BinaryPayloadBuilder(IPayloadBuilder):
         # Pack values back based on correct byte order   #
         # ---------------------------------------------- #
 
+        :param fstring:
         :param value: Value to be packed
         :return:
         """
@@ -141,7 +143,7 @@ class BinaryPayloadBuilder(IPayloadBuilder):
         they will be left padded with 0 bits to make
         it so.
 
-        :param value: The value to add to the buffer
+        :param values: The value to add to the buffer
         """
         value = pack_bitstring(values)
         self._payload.append(value)
@@ -295,6 +297,7 @@ class BinaryPayloadDecoder:
         :param byteorder: The Byte order of each word
         :param wordorder: The endianness of the word (when wordcount is >= 2)
         :returns: An initialized PayloadDecoder
+        :raises ParameterException:
         """
         _logger.debug(registers)
         if isinstance(registers, list):  # repack into flat binary
@@ -321,7 +324,9 @@ class BinaryPayloadDecoder:
 
         :param coils: The coil results to initialize with
         :param byteorder: The endianness of the payload
+        :param wordorder: The endianness of the payload
         :returns: An initialized PayloadDecoder
+        :raises ParameterException:
         """
         if isinstance(coils, list):
             payload = b""
@@ -342,6 +347,7 @@ class BinaryPayloadDecoder:
         # Change Word order if little endian word order  #
         # Pack values back based on correct byte order   #
         # ---------------------------------------------- #
+        :param fstring:
         :param handle: Value to be unpacked
         :return:
         """

--- a/pymodbus/pdu.py
+++ b/pymodbus/pdu.py
@@ -1,4 +1,5 @@
 """Contains base classes for modbus request/response/error packets."""
+# pylint: disable=missing-type-doc
 import logging
 import struct
 
@@ -69,7 +70,7 @@ class ModbusPDU:
         """Decode data part of the message.
 
         :param data: is a string object
-        :raises: A not implemented exception
+        :raises NotImplementedException:
         """
         raise NotImplementedException()
 
@@ -79,6 +80,7 @@ class ModbusPDU:
 
         :param buffer: A buffer containing the data that have been received.
         :returns: The number of bytes in the PDU.
+        :raises NotImplementedException:
         """
         if hasattr(cls, "_rtu_frame_size"):
             return cls._rtu_frame_size

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -1,4 +1,5 @@
 """Register Reading Request/Response."""
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.pdu import ModbusRequest
 from pymodbus.pdu import ModbusResponse

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -1,4 +1,5 @@
 """Register Writing Request/Response Messages."""
+# pylint: disable=missing-type-doc
 import struct
 from pymodbus.pdu import ModbusRequest
 from pymodbus.pdu import ModbusResponse

--- a/pymodbus/repl/client/completer.py
+++ b/pymodbus/repl/client/completer.py
@@ -3,6 +3,7 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
+# pylint: disable=missing-type-doc
 from prompt_toolkit.completion import Completer, Completion
 from prompt_toolkit.styles import Style
 from prompt_toolkit.filters import Condition
@@ -100,7 +101,7 @@ class CmdCompleter(Completer):
     def word_matches(self, word, word_before_cursor):
         """Match the word and word before cursor.
 
-        :param words: The input text broken into word tokens.
+        :param word: The input text broken into word tokens.
         :param word_before_cursor: The current word before the cursor, \
             which might be one or more blank spaces.
         :return: True if matched.

--- a/pymodbus/repl/client/helper.py
+++ b/pymodbus/repl/client/helper.py
@@ -3,6 +3,7 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
+# pylint: disable=missing-type-doc
 import json
 from collections import OrderedDict
 import inspect
@@ -251,7 +252,6 @@ class Result:
         :param formatters: int8/16/32/64, uint8/16/32/64, float32/64
         :param byte_order: little/big
         :param word_order: little/big
-        :return: Decoded Value
         """
         # Read Holding Registers (3)
         # Read Input Registers (4)
@@ -281,10 +281,7 @@ class Result:
             self.print_result(decoded)
 
     def raw(self):
-        """Return raw result dict.
-
-        :return:
-        """
+        """Return raw result dict."""
         self.print_result()
 
     def _process_dict(self, use_dict):
@@ -306,7 +303,6 @@ class Result:
         """Print result object pretty.
 
         :param data: Data to be printed.
-        :return:
         """
         data = data or self.data
         if isinstance(data, dict):

--- a/pymodbus/repl/client/mclient.py
+++ b/pymodbus/repl/client/mclient.py
@@ -3,6 +3,7 @@
 Copyright (c) 2018 Riptide IO, Inc. All Rights Reserved.
 
 """
+# pylint: disable=missing-type-doc
 import functools
 from pymodbus.pdu import ModbusExceptions, ExceptionResponse
 from pymodbus.exceptions import ModbusIOException
@@ -95,7 +96,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: The starting address to read from
         :param count: The number of coils to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :returns: List of register values
         """
         resp = super().read_coils(address, count, **kwargs)  # pylint: disable=no-member
@@ -108,7 +109,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: The starting address to read from
         :param count: The number of coils to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return: List of bits
         """
         resp = super().read_discrete_inputs(  # pylint: disable=no-member
@@ -124,7 +125,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: coil offset to write to
         :param value: bit value to write
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().write_coil(address, value, **kwargs)  # pylint: disable=no-member
@@ -136,7 +137,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: coil offset to write to
         :param values: list of bit values to write (comma separated)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().write_coils(  # pylint: disable=no-member
@@ -150,7 +151,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: register offset to write to
         :param value: register value to write
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().write_register(  # pylint: disable=no-member
@@ -164,7 +165,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: register offset to write to
         :param values: list of register value to write (comma separated)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().write_registers(  # pylint: disable=no-member
@@ -177,7 +178,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: starting register offset to read from
         :param count: Number of registers to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().read_holding_registers(  # pylint: disable=no-member
@@ -192,7 +193,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param address: starting register offset to read from to
         :param count: Number of registers to read
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().read_input_registers(  # pylint: disable=no-member
@@ -214,7 +215,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :param read_count: Number of registers to read
         :param write_address: register offset to write to
         :param write_registers: List of register values to write (comma separated)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().readwrite_registers(  # pylint: disable=no-member
@@ -236,7 +237,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         :param address: Reference address of register
         :param and_mask: And Mask
         :param or_mask: OR Mask
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         resp = super().mask_write_register(  # pylint: disable=no-member
@@ -256,7 +257,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         :param read_code:  Read Device ID code (0x01/0x02/0x03/0x04)
         :param object_id: Identification of the first object to obtain.
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReadDeviceInformationRequest(read_code, object_id, **kwargs)
@@ -276,7 +277,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
     def report_slave_id(self, **kwargs):
         """Report information about remote slave ID.
 
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReportSlaveIdRequest(**kwargs)
@@ -295,10 +296,8 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         In a remote device.
 
-        :param unit: The slave unit this request is targeting
-
+        :param kwargs:
         :return:
-
         """
         request = ReadExceptionStatusRequest(**kwargs)
         resp = self.execute(request)  # pylint: disable=no-member
@@ -311,10 +310,8 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
 
         From the remote device"s communication event counter.
 
-        :param unit: The slave unit this request is targeting
-
+        :param kwargs:
         :return:
-
         """
         request = GetCommEventCounterRequest(**kwargs)
         resp = self.execute(request)  # pylint: disable=no-member
@@ -332,7 +329,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         Event count, message count, and a field of event
         bytes from the remote device.
 
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = GetCommEventLogRequest(**kwargs)
@@ -362,7 +359,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Loop back data sent in response.
 
         :param message: Message to be looped back
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnQueryDataRequest(message, **kwargs)
@@ -374,7 +371,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         Serial interface and clear all of its communications event counters.
 
         :param toggle: Toggle Status [ON(0xff00)/OFF(0x0000]
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = RestartCommunicationsOptionRequest(toggle, **kwargs)
@@ -384,7 +381,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Read 16-bit diagnostic register.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnDiagnosticRegisterRequest(data, **kwargs)
@@ -394,7 +391,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Change message delimiter for future requests.
 
         :param data: New delimiter character
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ChangeAsciiInputDelimiterRequest(data, **kwargs)
@@ -404,7 +401,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Force addressed remote device to its Listen Only Mode.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ForceListenOnlyModeRequest(data, **kwargs)
@@ -414,7 +411,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Clear all counters and diag registers.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ClearCountersRequest(data, **kwargs)
@@ -424,7 +421,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of message detected on bus by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnBusMessageCountRequest(data, **kwargs)
@@ -434,7 +431,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of CRC errors received by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnBusCommunicationErrorCountRequest(data, **kwargs)
@@ -444,7 +441,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of Modbus exceptions returned by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnBusExceptionErrorCountRequest(data, **kwargs)
@@ -454,7 +451,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of messages addressed to remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnSlaveMessageCountRequest(data, **kwargs)
@@ -464,7 +461,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of No responses by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnSlaveNoResponseCountRequest(data, **kwargs)
@@ -474,7 +471,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of NO ACK exceptions sent by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnSlaveNAKCountRequest(data, **kwargs)
@@ -484,7 +481,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of server busy exceptions sent by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnSlaveBusyCountRequest(data, **kwargs)
@@ -496,7 +493,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         By remote slave due to character overrun condition.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnSlaveBusCharacterOverrunCountRequest(data, **kwargs)
@@ -506,7 +503,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Return count of iop overrun errors by remote slave.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ReturnIopOverrunCountRequest(data, **kwargs)
@@ -516,7 +513,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Clear over run counter.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = ClearOverrunCountRequest(data, **kwargs)
@@ -526,7 +523,7 @@ class ExtendedRequestSupport:  # pylint: disable=(too-many-public-methods
         """Get/clear stats of remote modbus plus device.
 
         :param data: Data field (0x0000)
-        :param unit: The slave unit this request is targeting
+        :param kwargs:
         :return:
         """
         request = GetClearModbusPlusRequest(  # pylint: disable=too-many-function-args

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -1,4 +1,5 @@
 """Implementation of a Threaded Modbus Server."""
+# pylint: disable=missing-type-doc
 import logging
 import warnings
 from binascii import b2a_hex
@@ -212,6 +213,7 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
         """Call with the resulting message.
 
         :param request: The decoded request message
+        :param addr: the address
         """
         broadcast = False
         try:
@@ -273,14 +275,15 @@ class ModbusBaseRequestHandler(asyncio.BaseProtocol):
     def _send_(self, data):  # pragma: no cover pylint: disable=no-self-use
         """Send a request (string) to the network.
 
-        :param message: The unencoded modbus response
+        :param data: The unencoded modbus response
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
     async def _recv_(self):  # pragma: no cover pylint: disable=no-self-use
         """Receive data from the network.
 
-        :return:
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
@@ -866,8 +869,7 @@ async def StartTcpServer(  # NOSONAR pylint: disable=invalid-name,dangerous-defa
     :param defer_start: if set, a coroutine which can be started and stopped
             will be returned. Otherwise, the server will be immediately spun
             up without the ability to shut it off from within the asyncio loop
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                      missing slave
+    :param kwargs: The rest
     :return: an initialized but inactive server object coroutine
     """
     framer = kwargs.pop("framer", ModbusSocketFramer)
@@ -915,8 +917,7 @@ async def StartTlsServer(  # NOSONAR pylint: disable=invalid-name,dangerous-defa
     :param defer_start: if set, a coroutine which can be started and stopped
             will be returned. Otherwise, the server will be immediately spun
             up without the ability to shut it off from within the asyncio loop
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                      missing slave
+    :param kwargs: The rest
     :return: an initialized but inactive server object coroutine
     """
     framer = kwargs.pop("framer", ModbusTlsFramer)
@@ -959,9 +960,8 @@ async def StartUdpServer(  # NOSONAR pylint: disable=invalid-name,dangerous-defa
     :param address: An optional (interface, port) to bind to.
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param framer: The framer to operate with (default ModbusSocketFramer)
-    :param ignore_missing_slaves: True to not send errors on a request
-                                    to a missing slave
+    :param defer_start: start with delay
+    :param kwargs:
     """
     framer = kwargs.pop("framer", ModbusSocketFramer)
     server = ModbusUdpServer(context, framer, identity, address, **kwargs)
@@ -987,15 +987,7 @@ async def StartSerialServer(  # NOSONAR pylint: disable=invalid-name,dangerous-d
     :param identity: An optional identify structure
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param framer: The framer to operate with (default ModbusAsciiFramer)
-    :param port: The serial port to attach to
-    :param stopbits: The number of stop bits to use
-    :param bytesize: The bytesize of the serial messages
-    :param parity: Which kind of parity to use
-    :param baudrate: The baud rate to use for the serial device
-    :param timeout: The timeout to use for the serial device
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                  missing slave
+    :param kwargs: The rest
     """
     framer = kwargs.pop("framer", ModbusAsciiFramer)
     server = ModbusSerialServer(context, framer, identity=identity, **kwargs)

--- a/pymodbus/server/asynchronous.py
+++ b/pymodbus/server/asynchronous.py
@@ -1,4 +1,5 @@
 """Implementation of a Twisted Modbus Server."""
+# pylint: disable=missing-type-doc
 import logging
 import threading
 from binascii import b2a_hex
@@ -172,7 +173,8 @@ class ModbusUdpProtocol(protocol.DatagramProtocol):
     def datagramReceived(self, datagram, addr):
         """Call when we receive any data.
 
-        :param data: The data sent by the client
+        :param datagram: The data sent by the client
+        :param addr: The address
         """
         txt = f"Client Connected [{addr}]"
         _logger.debug(txt)
@@ -187,6 +189,7 @@ class ModbusUdpProtocol(protocol.DatagramProtocol):
         """Execute the request and return the result.
 
         :param request: The decoded request message
+        :param addr: The address
         """
         try:
             context = self.store[request.unit_id]
@@ -244,15 +247,14 @@ def StartTcpServer(  # NOSONAR pylint: disable=dangerous-default-value,invalid-n
     """Start the Modbus Async TCP server.
 
     :param context: The server data context
-    :param identify: The server identity to use (default empty)
+    :param identity: The server identity to use (default empty)
     :param address: An optional (interface, port) to bind to.
     :param console: A flag indicating if you want the debug console
-    :param ignore_missing_slaves: True to not send errors on a request \
-    to a missing slave
     :param defer_reactor_run: True/False defer running reactor.run() as part \
     of starting server, to be explicitly started by the user
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
+    :param kwargs:
     """
     from twisted.internet import (  # pylint: disable=import-outside-toplevel,reimported
         reactor as local_reactor,
@@ -286,14 +288,13 @@ def StartUdpServer(  # NOSONAR pylint: disable=invalid-name,dangerous-default-va
     """Start the Modbus Async Udp server.
 
     :param context: The server data context
-    :param identify: The server identity to use (default empty)
+    :param identity: The server identity to use (default empty)
     :param address: An optional (interface, port) to bind to.
-    :param ignore_missing_slaves: True to not send errors on a request \
-    to a missing slave
     :param defer_reactor_run: True/False defer running reactor.run() as part \
     of starting server, to be explicitly started by the user
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
+    :param kwargs:
     """
     from twisted.internet import (  # pylint: disable=import-outside-toplevel,reimported
         reactor as local_reactor,
@@ -327,18 +328,13 @@ def StartSerialServer(  # NOSONAR pylint: disable=invalid-name,dangerous-default
     """Start the Modbus Async Serial server.
 
     :param context: The server data context
-    :param identify: The server identity to use (default empty)
+    :param identity: The server identity to use (default empty)
     :param framer: The framer to use (default ModbusAsciiFramer)
-    :param port: The serial port to attach to
-    :param baudrate: The baud rate to use for the serial device
-    :param console: A flag indicating if you want the debug console
-    :param ignore_missing_slaves: True to not send errors on a request to a
-           missing slave
     :param defer_reactor_run: True/False defer running reactor.run() as part
            of starting server, to be explicitly started by the user
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-
+    :param kwargs:
     """
     from twisted.internet import (  # pylint: disable=import-outside-toplevel,reimported
         reactor as local_reactor,

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -3,6 +3,7 @@
 Copyright (c) 2020 by RiptideIO
 All rights reserved.
 """
+# pylint: disable=missing-type-doc
 import os
 import sys
 import asyncio
@@ -133,7 +134,6 @@ class ReactiveServer:
         """Start Modbus server as asyncio task after startup.
 
         :param app: Webapp
-        :return:
         """
         try:
             if hasattr(asyncio, "create_task"):
@@ -162,7 +162,6 @@ class ReactiveServer:
         """Stop modbus server.
 
         :param app: Webapp
-        :return:
         """
         logger.info("Stopping modbus server")
         if isinstance(self._modbus_server, ModbusSerialServer):
@@ -190,7 +189,6 @@ class ReactiveServer:
         """Update manipulator config. Resets previous counters.
 
         :param config: Manipulator config (dict)
-        :return:
         """
         self._counter = 0
         self._manipulator_config = config
@@ -241,10 +239,7 @@ class ReactiveServer:
         return response, skip_encoding
 
     def run(self):
-        """Run Web app.
-
-        :return:
-        """
+        """Run Web app."""
 
         def _info(message):
             msg = HINT.format(message, self._host, self._port)
@@ -254,10 +249,7 @@ class ReactiveServer:
         web.run_app(self._web_app, host=self._host, port=self._port, print=_info)
 
     async def run_async(self):
-        """Run Web app.
-
-        :return:
-        """
+        """Run Web app."""
         try:
             await self._runner.setup()
             site = web.TCPSite(self._runner, self._host, self._port)

--- a/pymodbus/server/sync.py
+++ b/pymodbus/server/sync.py
@@ -1,4 +1,5 @@
 """Implementation of a Threaded Modbus Server."""
+# pylint: disable=missing-type-doc
 import logging
 import traceback
 from binascii import b2a_hex
@@ -94,6 +95,7 @@ class ModbusBaseRequestHandler(socketserver.BaseRequestHandler):
         """Send a request (string) to the network.
 
         :param message: The unencoded modbus response
+        :raises NotImplementedException:
         """
         raise NotImplementedException("Method not implemented by derived class")
 
@@ -366,7 +368,7 @@ class ModbusTcpServer(socketserver.ThreadingTCPServer):
         """Call for connecting a new client thread.
 
         :param request: The request to handle
-        :param client: The address of the client
+        :param client_address: The address of the client
         """
         txt = f"Started thread to serve client at {str(client_address)}"
         _logger.debug(txt)
@@ -509,7 +511,7 @@ class ModbusUdpServer(socketserver.ThreadingUDPServer):
         """Call for connecting a new client thread.
 
         :param request: The request to handle
-        :param client: The address of the client
+        :param client_address: The address of the client
         """
         _, _ = request  # TODO I might have to rewrite # pylint: disable=fixme
         txt = f"Started thread to serve client at {client_address}"
@@ -604,8 +606,6 @@ class ModbusSerialServer:  # pylint: disable=too-many-instance-attributes
         """Create and monkeypatch a serial handler.
 
         :param handler: a custom handler, uses ModbusSingleRequestHandler if set to None
-
-        :returns: A patched handler
         """
         request = self.socket
         request.send = request.write
@@ -653,8 +653,7 @@ def StartTcpServer(  # NOSONAR pylint: disable=invalid-name,dangerous-default-va
     :param address: An optional (interface, port) to bind to.
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                      missing slave
+    :param kwargs:
     """
     framer = kwargs.pop("framer", ModbusSocketFramer)
     server = ModbusTcpServer(context, framer, identity, address, **kwargs)
@@ -688,8 +687,7 @@ def StartTlsServer(  # NOSONAR pylint: disable=invalid-name,dangerous-default-va
     :param reqclicert: Force the sever request client"s certificate
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                      missing slave
+    :param kwargs:
     """
     framer = kwargs.pop("framer", ModbusTlsFramer)
     server = ModbusTlsServer(
@@ -724,9 +722,7 @@ def StartUdpServer(  # NOSONAR pylint: disable=invalid-name,dangerous-default-va
     :param address: An optional (interface, port) to bind to.
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param framer: The framer to operate with (default ModbusSocketFramer)
-    :param ignore_missing_slaves: True to not send errors on a request
-                                    to a missing slave
+    :param kwargs:
     """
     framer = kwargs.pop("framer", ModbusSocketFramer)
     server = ModbusUdpServer(context, framer, identity, address, **kwargs)
@@ -747,15 +743,8 @@ def StartSerialServer(  # NOSONAR pylint: disable=invalid-name, dangerous-defaul
     :param identity: An optional identify structure
     :param custom_functions: An optional list of custom function classes
         supported by server instance.
-    :param framer: The framer to operate with (default ModbusAsciiFramer)
-    :param port: The serial port to attach to
-    :param stopbits: The number of stop bits to use
-    :param bytesize: The bytesize of the serial messages
-    :param parity: Which kind of parity to use
-    :param baudrate: The baud rate to use for the serial device
-    :param timeout: The timeout to use for the serial device
-    :param ignore_missing_slaves: True to not send errors on a request to a
-                                  missing slave
+    :param kwargs:
+    :raises ConnectionException:
     """
     framer = kwargs.pop("framer", ModbusAsciiFramer)
     server = ModbusSerialServer(context, framer, identity=identity, **kwargs)

--- a/pymodbus/server/tls_helper.py
+++ b/pymodbus/server/tls_helper.py
@@ -1,4 +1,5 @@
 """TLS helper for Modbus TLS Server."""
+# pylint: disable=missing-type-doc
 import ssl
 
 

--- a/pymodbus/transaction.py
+++ b/pymodbus/transaction.py
@@ -1,5 +1,5 @@
 """Collection of transaction based abstractions."""
-
+# pylint: disable=missing-type-doc
 import logging
 import struct
 import socket
@@ -272,6 +272,7 @@ class ModbusTransactionManager:
         :param response_length:  Expected response length
         :param full: the target device was notorious for its no response. Dont
             waste time this time by partial querying
+        :param broadcast:
         :return: response
         """
         last_exception = None
@@ -428,6 +429,7 @@ class ModbusTransactionManager:
 
         :param request: The request to hold on to
         :param tid: The overloaded transaction id to use
+        :raises NotImplementedException:
         """
         raise NotImplementedException("addTransaction")
 
@@ -437,6 +439,7 @@ class ModbusTransactionManager:
         If the transaction does not exist, None is returned
 
         :param tid: The transaction to retrieve
+        :raises NotImplementedException:
         """
         raise NotImplementedException("getTransaction")
 
@@ -444,6 +447,7 @@ class ModbusTransactionManager:
         """Remove a transaction matching the referenced tid.
 
         :param tid: The transaction to remove
+        :raises NotImplementedException:
         """
         raise NotImplementedException("delTransaction")
 

--- a/pymodbus/utilities.py
+++ b/pymodbus/utilities.py
@@ -3,6 +3,7 @@
 A collection of utilities for packing data, unpacking
 data computing checksums, and decode checksums.
 """
+# pylint: disable=missing-type-doc
 import struct
 
 
@@ -127,7 +128,7 @@ def unpack_bitstring(string):
 def make_byte_string(byte_string):
     """Return byte string from a given string, python3 specific fix.
 
-    :param s:
+    :param byte_string:
     :return:
     """
     if isinstance(byte_string, str):

--- a/setup.cfg
+++ b/setup.cfg
@@ -75,6 +75,8 @@ include = pymodbus*
 
 # Add files or directories matching the regex patterns to the ignore-list.
 ignore-paths=
+    examples/common/tornado_twisted,
+    examples/contrib/tornado_twisted
 ignore-patterns=^\.#
 
 # Pickle collected data for later comparisons.
@@ -88,6 +90,7 @@ load-plugins=
     pylint.extensions.comparetozero,
     pylint.extensions.comparison_placement,
     pylint.extensions.confusing_elif,
+    pylint.extensions.docparams,
     pylint.extensions.docstyle,
     pylint.extensions.emptystring,
     pylint.extensions.eq_without_hash,
@@ -100,7 +103,6 @@ load-plugins=
 # NOT WANTED:
 #     pylint.extensions.broad_try_clause,
 #     pylint.extensions.consider_ternary_expression,
-#     pylint.extensions.docparams,
 #     pylint.extensions.empty_comment,
 #     pylint.extensions.redefined_variable_type,
 #     pylint.extensions.while_used,


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
This PR correct all missing/false parameter documentations.

At the moment there are circa 800 errors, so I believe it is safe to say that our documentation lack a bit.

I have submitted the PR to raise awareness that I have started on this work, however help is more than welcome.

To see the problems, download this PR "gh pr checkout 909", and run "tox -e pylint".