### PR TITLE
Secure all source code are part of coverage control

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,23 +3,6 @@ include =
     pymodbus/
     test/
 omit =
-    pymodbus/repl/*
-    pymodbus/internal/*
-    pymodbus/server/asyncio.py
-    pymodbus/server/reactive/*
-
     test/TO_DO_REWRITE
     examples/common/tornado_twister
     examples/contrib/tornado_twister
-
-    pymodbus/client/asynchronous/__init__.py
-    pymodbus/client/asynchronous/deprecated/*
-    pymodbus/client/asynchronous/thread.py
-    pymodbus/client/asynchronous/tornado/*
-    pymodbus/client/asynchronous/twisted/*
-    pymodbus/client/factory/serial.py
-    pymodbus/client/factory/tcp.py
-    pymodbus/client/factory/udp.py
-    pymodbus/server/async_io.py
-    pymodbus/server/asynchronous.py
-    version.py

--- a/tox.ini
+++ b/tox.ini
@@ -67,5 +67,5 @@ deps = -r requirements.txt
 commands =
     ls -la coverage_reports
     coverage combine coverage_reports
-    coverage report --fail-under=85 --ignore-errors
+    coverage report --fail-under=60 --ignore-errors
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
It is wrong to exclude source code, just because there are no tests in order to get a higher coverage score.

Removed all exludes, except those that really not should be controlled.
