### PR TITLE
updated time.sleep to 0.02s in _wait_for_data() under sync.py

### DIFF
--- a/pymodbus/client/sync.py
+++ b/pymodbus/client/sync.py
@@ -763,7 +763,7 @@ class ModbusSerialClient(
             if available and available != size:
                 more_data = True
                 size = available
-            time.sleep(0.01)
+            time.sleep(0.02)
         return size
 
     def _recv(self, size):


### PR DESCRIPTION
This pull request is created mainly to increase the "time.sleep" from 0.01 to 0.02s in _wait_for_data() under sync.py(line:766) since the **function code 43/14 - Read Device Identification** executed for Modbus RTU is getting failed when the time.sleep is 0.01s.

The following image shows the result of function code 43/14 execution when the time.sleep is 0.01
![image](https://user-images.githubusercontent.com/106981106/172350818-1e93c12d-7af1-44d3-a1dd-110f805074d2.png)
The above image shows that while executing the function code 43 there seem to be some incomplete bytes at the receiving end and which breaks the execution. While analyzing the flow of the function code 43 execution in pymodbus, we have ended up at one function named **_wait_for_data()** which is available under **pymodbus/client/sync.py**. 

In that when we increase the sleep time from 0.01 to 0.02, the same function code 43/14 is getting executed successfully as shown in the following image

![image](https://user-images.githubusercontent.com/106981106/172353327-2024da68-9d66-42e5-b7b0-31fea7637608.png)
Hence, I am raising this pull request with the above-mentioned change.  Kindly review this fix and provide your valuable suggestions.

**the sample code I have used to execute the function code 43 is as follows:**
'
from pymodbus.client.sync import ModbusTcpClient as ModbusTCPClient
from pymodbus.client.sync import ModbusSerialClient as ModbusClient
from pymodbus.payload import BinaryPayloadBuilder
from pymodbus.mei_message import *
from pymodbus.diag_message import *
from pymodbus.constants import *
from pymodbus.pdu import ExceptionResponse
from pymodbus.framer.socket_framer import *
from pymodbus.framer.rtu_framer import *
from pymodbus.factory import ClientDecoder
from pymodbus.transaction import ModbusTransactionManager
from pymodbus.payload import BinaryPayloadBuilder
from pymodbus.pdu import ModbusExceptions
from pymodbus.exceptions import ModbusException
#from utility.logger import Logger
import re
import struct
from pymodbus.bit_read_message import *
from pymodbus.bit_write_message import *
from pymodbus.register_read_message import *
from pymodbus.register_write_message import *
from pymodbus.utilities import computeCRC
from pymodbus.transaction import ModbusTransactionManager
from pymodbus.payload import BinaryPayloadBuilder
from pymodbus.mei_message import ReadDeviceInformationRequest
from pymodbus.pdu import ExceptionResponse
from pymodbus.pdu import ModbusExceptions
from pymodbus.exceptions import ModbusException
import time

class ModbusRTU():
    def __init__(self):
        self.connection = None
    def connect(self, method, port):
        self.connection = ModbusClient(method=method, port=port, baudrate=19200, parity='E', strict=False)
        if self.connection.connect():
            print("RTU Connected")

    def read_device_information(self):
        request = ReadDeviceInformationRequest(0, 1, unit=1)
        result = self.connection.execute(request)
        print(result)

modbusrtu = ModbusRTU()
modbusrtu.connect('rtu', 'COM4')
modbusrtu.read_device_information()
