### PR TITLE
Store method name in framer itself

### DIFF
--- a/pymodbus/framer/__init__.py
+++ b/pymodbus/framer/__init__.py
@@ -16,6 +16,8 @@ TLS_FRAME_HEADER = BYTE_ORDER + "B"
 class ModbusFramer(IModbusFramer):
     """Base Framer class."""
 
+    name = ''
+
     def _validate_unit_id(self, units, single):
         """Validate if the received data is valid for the client.
 

--- a/pymodbus/framer/ascii_framer.py
+++ b/pymodbus/framer/ascii_framer.py
@@ -34,6 +34,8 @@ class ModbusAsciiFramer(ModbusFramer):
     the data in this framer is transferred in plain text ascii.
     """
 
+    method = 'ascii'
+
     def __init__(self, decoder, client=None):
         """Initialize a new instance of the framer.
 

--- a/pymodbus/framer/binary_framer.py
+++ b/pymodbus/framer/binary_framer.py
@@ -43,6 +43,8 @@ class ModbusBinaryFramer(ModbusFramer):
     Protocol defined by jamod.sourceforge.net.
     """
 
+    method = 'binary'
+
     def __init__(self, decoder, client=None):
         """Initialize a new instance of the framer.
 

--- a/pymodbus/framer/rtu_framer.py
+++ b/pymodbus/framer/rtu_framer.py
@@ -57,6 +57,8 @@ class ModbusRtuFramer(ModbusFramer):
         (1/Baud)(bits) = delay seconds
     """
 
+    method = 'rtu'
+
     def __init__(self, decoder, client=None):
         """Initialize a new instance of the framer.
 

--- a/pymodbus/framer/socket_framer.py
+++ b/pymodbus/framer/socket_framer.py
@@ -36,6 +36,8 @@ class ModbusSocketFramer(ModbusFramer):
         * The -1 is to account for the uid byte
     """
 
+    method = 'socket'
+
     def __init__(self, decoder, client=None):
         """Initialize a new instance of the framer.
 

--- a/pymodbus/framer/tls_framer.py
+++ b/pymodbus/framer/tls_framer.py
@@ -28,6 +28,8 @@ class ModbusTlsFramer(ModbusFramer):
           1b               Nb
     """
 
+    method = 'tls'
+
     def __init__(self, decoder, client=None):
         """Initialize a new instance of the framer.
 


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
Currently texts like "ascii" is distributed out in the code, put the name (text) in the framer itself, makes a fixed relationship, which can be easier controlled.

This is the first part of a more generic change where the different client/server classes only will allow framers valid for the type of communication and otherwise throw an exception. The generic change also includes support for a custom framer to be supplied by the calling app, without overwriting our code.