### PR TITLE
Fix mask write register

### DIFF
--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -2,11 +2,7 @@
 # pylint: disable=missing-type-doc
 import struct
 
-from pymodbus.pdu import (
-    ModbusExceptions as merror,
-    ModbusRequest,
-    ModbusResponse,
-)
+from pymodbus.pdu import ModbusExceptions as merror, ModbusRequest, ModbusResponse
 
 
 class WriteSingleRegisterRequest(ModbusRequest):

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -2,7 +2,11 @@
 # pylint: disable=missing-type-doc
 import struct
 
-from pymodbus.pdu import ModbusExceptions as merror, ModbusRequest, ModbusResponse
+from pymodbus.pdu import (
+    ModbusExceptions as merror,
+    ModbusRequest,
+    ModbusResponse,
+)
 
 
 class WriteSingleRegisterRequest(ModbusRequest):
@@ -313,7 +317,7 @@ class MaskWriteRegisterRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
         values = context.getValues(self.function_code, self.address, 1)[0]
-        values = (values & self.and_mask) | (self.or_mask & ~self.and_ask)
+        values = (values & self.and_mask) | (self.or_mask & ~self.and_mask)
         context.setValues(self.function_code, self.address, [values])
         return MaskWriteRegisterResponse(self.address, self.and_mask, self.or_mask)
 

--- a/pymodbus/register_write_message.py
+++ b/pymodbus/register_write_message.py
@@ -313,7 +313,7 @@ class MaskWriteRegisterRequest(ModbusRequest):
         if not context.validate(self.function_code, self.address, 1):
             return self.doException(merror.IllegalAddress)
         values = context.getValues(self.function_code, self.address, 1)[0]
-        values = (values & self.and_mask) | self.or_mask
+        values = (values & self.and_mask) | (self.or_mask & ~self.and_ask)
         context.setValues(self.function_code, self.address, [values])
         return MaskWriteRegisterResponse(self.address, self.and_mask, self.or_mask)
 

--- a/test/modbus_mocks.py
+++ b/test/modbus_mocks.py
@@ -29,6 +29,7 @@ class MockContext(IModbusSlaveContext):
     def setValues(self, fx, address, values):
         """Set values."""
 
+
 class MockLastValuesContext(IModbusSlaveContext):
     """Mock context."""
 
@@ -49,6 +50,7 @@ class MockLastValuesContext(IModbusSlaveContext):
     def setValues(self, fx, address, values):
         """Set values."""
         self.last_values = values
+
 
 class FakeList:
     """Todo, replace with magic mock."""

--- a/test/modbus_mocks.py
+++ b/test/modbus_mocks.py
@@ -29,6 +29,26 @@ class MockContext(IModbusSlaveContext):
     def setValues(self, fx, address, values):
         """Set values."""
 
+class MockLastValuesContext(IModbusSlaveContext):
+    """Mock context."""
+
+    def __init__(self, valid=False, default=True):
+        """Initialize."""
+        self.valid = valid
+        self.default = default
+        self.last_values = []
+
+    def validate(self, fx, address, count=0):
+        """Validate values."""
+        return self.valid
+
+    def getValues(self, fx, address, count=0):
+        """Get values."""
+        return [self.default] * count
+
+    def setValues(self, fx, address, values):
+        """Set values."""
+        self.last_values = values
 
 class FakeList:
     """Todo, replace with magic mock."""

--- a/test/test_register_write_messages.py
+++ b/test/test_register_write_messages.py
@@ -138,6 +138,12 @@ class WriteRegisterMessagesTest(unittest.TestCase):
 
     def test_mask_write_register_request_execute(self):
         """Test write register request valid execution"""
+        # The test uses the 4 nibbles of the 16-bit values to test
+        # the combinations:
+        #     and_mask=0, or_mask=0
+        #     and_mask=F, or_mask=0
+        #     and_mask=0, or_mask=F
+        #     and_mask=F, or_mask=F
         context = MockLastValuesContext(valid=True, default=0xAA55)
         handle = MaskWriteRegisterRequest(0x0000, 0x0F0F, 0x00FF)
         result = handle.execute(context)

--- a/test/test_register_write_messages.py
+++ b/test/test_register_write_messages.py
@@ -13,7 +13,7 @@ from pymodbus.register_write_message import (
     WriteSingleRegisterResponse,
 )
 
-from .modbus_mocks import MockContext
+from .modbus_mocks import MockContext, MockLastValuesContext
 
 # ---------------------------------------------------------------------------#
 #  Fixture
@@ -138,10 +138,11 @@ class WriteRegisterMessagesTest(unittest.TestCase):
 
     def test_mask_write_register_request_execute(self):
         """Test write register request valid execution"""
-        context = MockContext(valid=True, default=0x0000)
-        handle = MaskWriteRegisterRequest(0x0000, 0x0101, 0x1010)
+        context = MockLastValuesContext(valid=True, default=0xAA55)
+        handle = MaskWriteRegisterRequest(0x0000, 0x0F0F, 0x00FF)
         result = handle.execute(context)
         self.assertTrue(isinstance(result, MaskWriteRegisterResponse))
+        self.assertEqual([0x0AF5], context.last_values)
 
     def test_mask_write_register_request_invalid_execute(self):
         """Test write register request execute with invalid data"""


### PR DESCRIPTION
According to the spec the "Mask Write Register" function ands the
or-mask with ~and-mask.

See section 6.16 of the specification (v1.1b3):
```
Result = (Current Contents AND And_Mask) OR (Or_Mask AND (NOT And_Mask))
```
