### PR TITLE
Fix port typo

### DIFF
--- a/pymodbus/client/async_tcp.py
+++ b/pymodbus/client/async_tcp.py
@@ -39,7 +39,7 @@ class AsyncModbusTcpClient:  # pylint: disable=too-many-instance-attributes
     r"""Modbus client for async TCP communication.
 
     :param host: (positional) Host IP address
-    :param port: (optional default 502) The serial port used for communication.
+    :param port: (optional default 502) The TCP port used for communication.
     :param protocol_class: (optional, default ModbusClientProtocol) Protocol communication class.
     :param modbus_decoder: (optional, default ClientDecoder) Message decoder class.
     :param framer: (optional, default ModbusSocketFramer) Framer class.

--- a/pymodbus/client/sync_tcp.py
+++ b/pymodbus/client/sync_tcp.py
@@ -43,7 +43,7 @@ class ModbusTcpClient(BaseOldModbusClient):  # pylint: disable=too-many-instance
     r"""Modbus client for TCP communication.
 
     :param host: (positional) Host IP address
-    :param port: (optional default 502) The serial port used for communication.
+    :param port: (optional default 502) The TCP port used for communication.
     :param protocol_class: (optional, default ModbusClientProtocol) Protocol communication class.
     :param modbus_decoder: (optional, default ClientDecoder) Message decoder class.
     :param framer: (optional, default ModbusSocketFramer) Framer class.


### PR DESCRIPTION
I'm trying to keep abreast of breaking changes for a downstream driver [numat/productivity](https://github.com/numat/productivity) and ran across a typo.