### PR TITLE
Update async example. With this simple spinning up a client/server should work again.

### DIFF
--- a/examples/server_sync.py
+++ b/examples/server_sync.py
@@ -147,12 +147,12 @@ def run_server():
             # TBD host=
             # TBD port=
             address=("", port),  # listen address
-            custom_functions=[],  # allow custom handling
+            # custom_functions=[],  # allow custom handling
             framer=framer,  # The framer strategy to use
             # TBD handler=None,  # handler for each session
             allow_reuse_address=True,  # allow the reuse of an address
-            ignore_missing_slaves=True,  # ignore request to a missing slave
-            broadcast_enable=False,  # treat unit_id 0 as broadcast address,
+            # ignore_missing_slaves=True,  # ignore request to a missing slave
+            # broadcast_enable=False,  # treat unit_id 0 as broadcast address,
             # TBD timeout=1,  # waiting time for request to complete
             # TBD strict=True,  # use strict timing, t1.5 for Modbus RTU
         )

--- a/pymodbus/client/async_tcp.py
+++ b/pymodbus/client/async_tcp.py
@@ -74,7 +74,6 @@ class AsyncModbusTcpClient(ModbusBaseClient):
     async def aConnect(self):
         """Initiate connection to start client."""
         # force reconnect if required:
-        await self.aClose()
         self.loop = asyncio.get_running_loop()
 
         txt = f"Connecting to {self.params.host}:{self.params.port}."
@@ -83,15 +82,15 @@ class AsyncModbusTcpClient(ModbusBaseClient):
 
     async def aClose(self):
         """Stop client."""
-        # prevent reconnect:
-        self.params.host = None
-
         if self.connected and self.protocol and self.protocol.transport:
             self.protocol.transport.close()
 
+        # prevent reconnect.
+        self.params.host = None
+
     def _create_protocol(self):
         """Create initialized protocol instance with factory function."""
-        protocol = ModbusClientProtocol(**self.params.kwargs)
+        protocol = ModbusClientProtocol(framer=self.params.framer, **self.params.kwargs)
         protocol.factory = self
         return protocol
 

--- a/pymodbus/client/async_udp.py
+++ b/pymodbus/client/async_udp.py
@@ -102,7 +102,11 @@ class AsyncModbusUdpClient(ModbusBaseClient):
 
     def _create_protocol(self, host=None, port=0):
         """Create initialized protocol instance with factory function."""
-        protocol = ModbusClientProtocol(use_udp=True, **self.params.kwargs)
+        protocol = ModbusClientProtocol(
+            use_udp=True,
+            framer=self.params.framer,
+            **self.params.kwargs
+        )
         protocol.params.host = host
         protocol.port = port
         protocol.factory = self

--- a/pymodbus/client/base.py
+++ b/pymodbus/client/base.py
@@ -95,7 +95,7 @@ class ModbusBaseClient(ModbusClientMixin):
         **kwargs
     ):
         """Initialize a client instance."""
-        self.params = self._params
+        self.params = self._params()
         self.params.framer = framer
         self.params.timeout = timeout
         self.params.retries = retries

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -118,7 +118,7 @@ class SynchronousClientTest(
         self.assertRaises(NotImplementedException, client.connect)
         self.assertRaises(NotImplementedException, client.is_socket_open)
         self.assertRaises(NotImplementedException, client.close)
-        self.assertEqual("ModbusBaseClient None:502", str(client))
+        self.assertEqual("ModbusBaseClient None:None", str(client))
 
         # Test information methods
         client.last_frame_end = 2

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -1,0 +1,55 @@
+"""Test client async."""
+
+
+import logging
+import pytest
+
+
+_logger = logging.getLogger()
+
+# ---------------------------------------------------------------------------#
+# Fixture
+# ---------------------------------------------------------------------------#
+
+
+@pytest.mark.parametrize(
+    "sync_server, sync_client",
+    [
+        (True, True),
+        (True, False),
+        (False, True),
+        (False, False),
+    ]
+)
+@pytest.mark.parametrize(
+    "test_comm, test_framer",
+    [
+        ("tcp", "socket"),
+        ("tcp", "rtu"),
+        ("tcp", "ascii"),
+        ("tcp", "binary"),
+        ("udp", "socket"),
+        ("udp", "rtu"),
+        ("udp", "ascii"),
+        ("udp", "binary"),
+        ("serial", "rtu"),
+        ("serial", "ascii"),
+        ("serial", "binary"),
+        # TLS is not automatic testable, without a certificate
+    ]
+)
+def test_dummy(sync_server, sync_client, test_comm, test_framer):
+    """Dummy."""
+    txt = f"testing: {sync_server}, {sync_client}, {test_comm}, {test_framer}"
+    _logger.info(txt)
+
+    # start server
+
+    # run client as:
+    #    client_X.py
+    #    client_X_basic_calls.py
+    #    client_X_extended_calls.py
+
+    # stop client
+
+    # stop server


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

Next up, is an automation, because making all the combinations:
- sync/async client/server
- tcp/udp/serial (tls needs a certificate that is for later)
- framer ascii, binary....

makes me sure, this was never repeated consistently, hence the automation.
