### PR TITLE
Add timeout to all pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,4 +69,5 @@ pylint==2.14.5
 pytest==7.1.2
 pytest-asyncio==0.18.3
 pytest-cov==3.0.0
+pytest-timeout==2.1.0
 tox==3.25.0

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py{38,39,310,py38}
 [testenv]
 deps = -r requirements.txt
 commands =
-    pytest {posargs:--cov=pymodbus --cov=test --cov-report=term-missing --cov-report=xml -v --full-trace}
+    pytest {posargs:--cov=pymodbus --cov=test --cov-report=term-missing --cov-report=xml -v --full-trace --timeout=5}
 passenv =
     INCLUDE
     LIB


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
No test should take longer than 5 seconds, so lets assure we do not have hanging tests.
