### PR TITLE
Solve example server startup and fix #1087

### DIFF
--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -313,4 +313,4 @@ def get_commandline():
 
 
 if __name__ == "__main__":
-    asyncio.run(run_async_server("."), debug=True)
+    asyncio.run(run_async_server(), debug=True)

--- a/examples/server_sync.py
+++ b/examples/server_sync.py
@@ -313,5 +313,5 @@ def get_commandline():
 
 
 if __name__ == "__main__":
-    server = run_sync_server(".")
+    server = run_sync_server()
     server.shutdown()


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
When running the serial async example (server/client) everything works as documented:
```
./server_async.py --comm serial --port /dev/ttys004
13:06:09 INFO  server_async:71 ### Create datastore
13:06:09 INFO  server_async:158 ### start ASYNC server on port /dev/ttys004
13:06:54 ERROR async_io:100 Handler for serial port has been cancelled
```
and
```
./client_async_basic_calls.py --comm serial --port /dev/ttys005
13:06:38 INFO  client_async:52 ### Create client object
13:06:38 INFO  client_async:129 ### Client starting
13:06:38 INFO  serial:115 Serial connected.
13:06:38 INFO  serial:108 Connected to /dev/ttys005
13:06:38 INFO  client_async_basic_calls:20 ### Reading Coil
13:06:38 INFO  client_async_basic_calls:26 ### Reading Coils to get bit 5
13:06:38 INFO  client_async_basic_calls:32 ### Write true to coil bit 0 and read to verify
13:06:38 INFO  client_async_basic_calls:40 ### Write true to multiple coils 1-8
13:06:38 INFO  client_async_basic_calls:53 ### Write False to address 1-8 coils
13:06:38 INFO  client_async_basic_calls:64 ### Reading discrete input, Read address:0-7
13:06:38 INFO  client_async_basic_calls:73 ### write holding register and read holding registers
13:06:38 INFO  client_async_basic_calls:81 ### write holding registers and read holding registers
13:06:38 INFO  client_async_basic_calls:89 ### write read holding registers
13:06:38 INFO  client_async_basic_calls:107 ### read input registers
13:06:38 INFO  client_async:135 ### End of Program
13:06:38 INFO  serial:125 Serial lost connection.
```

so it seems clear the #1087 either do not use the current dev or does something else not needed. Since we do not have the full code it is hard to point at the problem.

fixes #1087


There was a problem in the server examples with the start parameter (due to tls), this is corrected.