### PR TITLE
Remove call to configure logging

### DIFF
--- a/pymodbus/constants.py
+++ b/pymodbus/constants.py
@@ -3,17 +3,7 @@
 This is the single location for storing default
 values for the servers and clients.
 """
-import logging
-
 from pymodbus.interfaces import Singleton
-
-
-# set logging format and default level for library.
-logging.basicConfig(
-    format="%(asctime)s %(levelname)-5s %(module)s:%(lineno)s %(message)s",
-    datefmt="%H:%M:%S",
-    level=logging.WARNING,
-)
 
 
 class Defaults(Singleton):  # pylint: disable=too-few-public-methods


### PR DESCRIPTION
This call configures logging for the whole process, not only the Pymodbus module, so it affects the application using this library.
