### PR TITLE
Bugfix ModbusSerialServer setup so handler is called correctly.

### DIFF
--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -841,7 +841,7 @@ class ModbusSerialServer:  # pylint: disable=too-many-instance-attributes
         try:
             self.transport, self.protocol = await create_serial_connection(
                 asyncio.get_event_loop(),
-                self.handler(self),
+                lambda: self.handler(self),
                 self.device,
                 baudrate=self.baudrate,
                 bytesize=self.bytesize,


### PR DESCRIPTION
I was hit by ModbusSerialServer being broken by the previous commit to async_io.py.

There is no test covering ModbusSerialServer which is probably why this got through. One could be added using pty.openpty.