### PR TITLE
Obey timeout parameter on connection

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -105,6 +105,7 @@ class AsyncModbusSerialClient(ModbusBaseClient):
                 bytesize=self.params.bytesize,
                 stopbits=self.params.stopbits,
                 parity=self.params.parity,
+                timeout=self.params.timeout,
                 **self.params.kwargs,
             )
             await self._connected_event.wait()

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -83,8 +83,11 @@ class AsyncModbusTcpClient(ModbusBaseClient):
         """Connect."""
         _logger.debug("Connecting.")
         try:
-            transport, protocol = await self.loop.create_connection(
-                self._create_protocol, host=self.params.host, port=self.params.port
+            transport, protocol = await asyncio.wait_for(
+                self.loop.create_connection(
+                    self._create_protocol, host=self.params.host, port=self.params.port
+                ),
+                timeout=self.params.timeout,
             )
             return transport, protocol
         except Exception as exc:  # pylint: disable=broad-except


### PR DESCRIPTION
Closes #1130

I'm not sure if it's worth having separate timeout parameters for the initial connection and subsequent requests.  This takes the simpler approach
