### PR TITLE
Add Docker and container registry support 

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
+
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
       
       - name: Log in to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -12,9 +12,6 @@ name: Publish Docker image
 on:
   release:
     types: [published]
-env:
-  DOCKER_HUB_NAMESPACE: serroba
-  DOCKER_HUB_REPOSITORY: pymodbus
 
 jobs:
   push_to_registry:
@@ -42,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
+          images: ${{ github.repository }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -7,40 +7,32 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Create and publish a Docker image
+name: Publish Docker image
 
 on:
-  push:
-    branches: ['release']
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  release:
+    types: [published]
 
 jobs:
-  build-and-push-image:
+  push_to_registry:
+    name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-
     steps:
-      - name: Checkout repository
+      - name: Check out the repo
         uses: actions/checkout@v3
-
-      - name: Log in to the Container registry
+      
+      - name: Log in to Docker Hub
         uses: docker/login-action@v2
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
+          images: my-docker-hub-namespace/my-docker-hub-repository
+      
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -48,7 +48,7 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -12,6 +12,9 @@ name: Publish Docker image
 on:
   release:
     types: [published]
+env:
+  DOCKER_HUB_NAMESPACE: serroba
+  DOCKER_HUB_REPOSITORY: pymodbus
 
 jobs:
   push_to_registry:
@@ -31,7 +34,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: my-docker-hub-namespace/my-docker-hub-repository
+          images: ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
       
       - name: Build and push Docker image
         uses: docker/build-push-action@v3

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,50 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# GitHub recommends pinning actions to a commit SHA.
+# To get a newer version, you will need to update the SHA.
+# You can also reference a tag or branch, but the action may change without warning.
+
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['release']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,40 +7,44 @@
 # To get a newer version, you will need to update the SHA.
 # You can also reference a tag or branch, but the action may change without warning.
 
-name: Publish Docker image
+name: Create and publish a Docker image
 
 on:
   release:
     types: [published]
+
 env:
-  DOCKER_HUB_NAMESPACE: serroba
-  DOCKER_HUB_REPOSITORY: pymodbus
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - name: Check out the repo
+      - name: Checkout repository
         uses: actions/checkout@v3
-      
-      - name: Log in to Docker Hub
+
+      - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.DOCKER_HUB_NAMESPACE }}/${{ env.DOCKER_HUB_REPOSITORY }}
-      
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@
 
 FROM python:3.8-slim-buster
 
-WORKDIR /app
-
-COPY requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+WORKDIR /pymodbus
 
 COPY . .
+
+RUN pip3 install -r requirements.txt && pip3 install -e .
+

--- a/README.rst
+++ b/README.rst
@@ -197,6 +197,10 @@ Or to install a specific release:
 
     pip install -U pymodbus==X.Y.Z
 
+You can also use Docker to run a local image with the package installed on the image:
+
+    docker pull riptideio/pymodbus
+
 Otherwise you can pull the trunk source and install from there::
 
     git clone git://github.com/riptideio/pymodbus.git

--- a/README.rst
+++ b/README.rst
@@ -245,14 +245,12 @@ Docker Compose
 ------------------------------------------------------------
 
 If you would like to use this image as part of a `docker compose` project, you can provide a custom command. For example,
-you can spin the server by creating a docker compose file containing the following:
+you can spin the server by creating a docker compose file containing the following::
 
-```yml
-pymodbus-server:
-    container_name: pymodbus-server
-    image: riptideio/pymodbus:X.Y.Z
-    command: ["./examples/server_sync.py"]
-```
+   pymodbus-server:
+      container_name: pymodbus-server
+      image: riptideio/pymodbus:X.Y.Z
+      command: ["./examples/server_sync.py"]
 
 After running `docker compose up`, you should have running the `server_sync.py` example, ready to accept connections from a client. You can,
 of course, add a custom script instead, to run your own logic instead.

--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,23 @@ Either method will install all the required dependencies
 (at their appropriate versions) for your current python distribution.
 
 ------------------------------------------------------------
+Docker Compose
+------------------------------------------------------------
+
+If you would like to use this image as part of a `docker compose` project, you can provide a custom command. For example,
+you can spin the server by creating a docker compose file containing the following:
+
+```yml
+pymodbus-server:
+    container_name: pymodbus-server
+    image: riptideio/pymodbus:X.Y.Z
+    command: ["./examples/server_sync.py"]
+```
+
+After running `docker compose up`, you should have running the `server_sync.py` example, ready to accept connections from a client. You can,
+of course, add a custom script instead, to run your own logic instead.
+
+------------------------------------------------------------
 Repository structure
 ------------------------------------------------------------
 The repository contains a number of important branches and tags.

--- a/pymodbus/repl/client/README.md
+++ b/pymodbus/repl/client/README.md
@@ -15,6 +15,12 @@ Install pymodbus with repl support
 $ pip install pymodbus[repl] --upgrade
 ```
 
+## Docker
+Pull Docker image with everything installed
+
+`docker pull riptideio/pymodbus`
+
+
 ## Usage Instructions
 RTU and TCP are supported as of now
 
@@ -32,7 +38,9 @@ Commands:
   serial
   tcp
 
+# Or using a Docker run command instead
 
+✗ docker run -it riptideio/pymodbus pymodbus.console --help
 ```
 TCP Options
 

--- a/pymodbus/repl/server/README.md
+++ b/pymodbus/repl/server/README.md
@@ -19,6 +19,11 @@ Install `pymodbus` with the required dependencies
 
 `pip install pymodbus[repl]`
 
+## Docker
+Pull Docker image with everything installed
+
+`docker pull riptideio/pymodbus`
+
 ## Usage
 
 Invoke REPL server with `pymodbus.server run` command.
@@ -44,6 +49,12 @@ Invoke REPL server with `pymodbus.server run` command.
 ╭─ Commands ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ run              Run Reactive Modbus server.                                                                               │
 ╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+```
+
+If using the docker image, you can run all the same commands, prepending the `docker run` command. For example:
+
+```shell
+docker run -it riptideio/pymodbus pymodbus.server --help
 ```
 
 ```shell


### PR DESCRIPTION
# What?

This PR adds support to create docker images locally against the current working environment
Additionally, this PR is adding the required scripts to automatically create docker images and publish them to public repositories -Docker Hub and GitHub Container Registry (ghcr), as a package.

When publishing to Docker Hub, in this PR, we are publishing images built for `linux/amd64` and `linux/arm64`. Additional platform can be easily expanded if there is more need for that.

# Why?

This can greatly accelerate the exploration of this library. As an external user, the ability to interact with the library and potentially spin up servers and play with the clients can drastically reduce the need to learn the more lower level aspects of the library. This also makes very easy the ability to import the library in a larger project using `docker-compose`.

Additionally, this is a continuation of the conversation I had with @janiversen a few weeks ago: https://github.com/riptideio/pymodbus/commit/4b57def1eea90fb9575b608ac24109c72107dc0c#r86307726


# Testing/Proof

I tested this against my own fork. I tried several times until I got it working. 

The GH actions can be seen here:

https://github.com/serroba/pymodbus/actions

Of particular interest:

* Publishing to Docker Hub: https://github.com/serroba/pymodbus/actions/runs/3297517052/jobs/5438427074
* Publishing as a GitHub package or ghcr: https://github.com/serroba/pymodbus/actions/runs/3297517075/jobs/5438427120

# Container Images Registries

## Docker Hub

To test proper integration with Docker Hub, I created my own repository with the equivalent of this project. The images can be seen on: https://hub.docker.com/repository/docker/serroba/pymodbus


## GitHub Container Registry

To test this, the integration is native, so no need to do anything outside this PR here: https://github.com/serroba/pymodbus/pkgs/container/pymodbus

# Examples and usage with Docker Compose:

I have forked an existent public repository https://github.com/huntabyte/tig-stack and the now created image using this PR

Example:

```
  pymodbus-server:
    container_name: pymodbus-server
    image: serroba/pymodbus:v3.0.0dev5
    command: ["./examples/server_sync.py"]
```


Things are working as expected:
<img width="828" alt="image" src="https://user-images.githubusercontent.com/1817347/197312457-c7857451-5ac4-44ea-bfef-28bad5ff253d.png">


Also, we can just things directly in the container:

```
docker run -it serroba/pymodbus:v3.0.0dev5 examples/server_sync.py
```

<img width="675" alt="image" src="https://user-images.githubusercontent.com/1817347/197314647-1cc33317-4fa1-4d74-8438-10439e8fa9e6.png">

Or enter the REPL using the images:

```
docker run -it serroba/pymodbus:v3.0.0dev5 pymodbus.server run --modbus-server tcp --framer socket --unit-id 1 --unit-id 4 --random 2
```

<img width="1148" alt="image" src="https://user-images.githubusercontent.com/1817347/197314691-78ea1a63-8586-4418-a24b-17579df6818b.png">

