### PR TITLE
removes undue reported error when forwarding

### DIFF
--- a/pymodbus/datastore/remote.py
+++ b/pymodbus/datastore/remote.py
@@ -73,7 +73,7 @@ class RemoteSlaveContext(IModbusSlaveContext):
         """Build the function code mapper."""
         kwargs = {}
         if self.unit:
-            kwargs["unit"] = self.unit
+            kwargs["slave"] = self.unit
         self.__get_callbacks = {
             "d": lambda a, c: self._client.read_discrete_inputs(  # pylint: disable=unnecessary-lambda
                 a, c, **kwargs

--- a/pymodbus/register_read_message.py
+++ b/pymodbus/register_read_message.py
@@ -49,7 +49,7 @@ class ReadRegistersRequestBase(ModbusRequest):
 
         :returns: A string representation of the instance
         """
-        return f"ReadRegisterRequest ({self.address},{self.count})"
+        return f"{self.__class__.__name__} ({self.address},{self.count})"
 
 
 class ReadRegistersResponseBase(ModbusResponse):


### PR DESCRIPTION
the first commit solves a cosmetic problem mentionned in the discussion : https://github.com/riptideio/pymodbus/discussions/1110#discussioncomment-3871293

it removes the following undue error, reported when running a TCP server forwarding a serial server :
```
17:10:21 ERROR mixin:113 Please do not use unit=, convert to slave=.
````

the second commit is a suggestion of homogeneisation in register_read_message.py
