### PR TITLE
Fix #1118 

### DIFF
--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 from enum import Enum
 
+
 try:
     from aiohttp import web
 except ImportError:

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -7,7 +7,7 @@ import os
 import random
 import sys
 import time
-
+from enum import Enum
 
 try:
     from aiohttp import web
@@ -368,6 +368,9 @@ class ReactiveServer:
         :              refer corresponding servers documentation
         :return: ReactiveServer object
         """
+        if isinstance(server, Enum):
+            server = server.value
+
         if server.lower() not in SERVER_MAPPER:
             txt = f"Invalid server {server}"
             logger.error(txt)


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

for python 3.9 and above. Resolve `enum` to its value if getting passed as `enum` rather than `string`.