### PR TITLE
Repl enhancements 2

### DIFF
--- a/pymodbus/repl/server/README.md
+++ b/pymodbus/repl/server/README.md
@@ -211,7 +211,7 @@ curl -X POST http://localhost:8080 -d '{"response_type": "delayed", "delay_by": 
 
 ```
 
-**Rever to normal responses**
+**Revert to normal responses**
 
 ```
 curl -X POST http://localhost:8080 -d '{"response_type": "normal"}'

--- a/pymodbus/repl/server/README.md
+++ b/pymodbus/repl/server/README.md
@@ -120,3 +120,104 @@ Usage: manipulator response_type=|normal|error|delayed|empty|stray
 ```
 
 [![Pymodbus Server REPL](https://img.youtube.com/vi/OutaVz0JkWg/maxresdefault.jpg)](https://youtu.be/OutaVz0JkWg)
+
+
+### Pymodbus Server Non REPL Mode
+To run the Reactive server in the non-repl mode use `--no-repl` flag while starting the server. The server responses can still be manipulated with REST API calls.
+
+```
+pymodbus.server --no-repl --verbose run  --modbus-server tcp --framer socket --unit-id 1 --unit-id 4 --random 2 --modbus-port 5020
+2022-10-27 13:32:56,062 MainThread      INFO     main           :246      Modbus server started
+
+Reactive Modbus Server started.
+======== Running on http://localhost:8080 ========
+
+===========================================================================
+Example Usage:
+curl -X POST http://localhost:8080 -d "{"response_type": "error", "error_code": 4}"
+===========================================================================
+```
+
+#### REST API
+
+The server response can be manipulated by doing a `POST` request on the web-server running `http://<host>:<port>`. The values for `host` and `port`
+can be modified with `--host` and `--web-port` params while starting the server. The default values are `localhost` and `8080`
+
+```
+pymodbus.server --host <host-ip> --web-port <new-port> run .....
+
+```
+
+The payload for the `POST` requests is 
+
+```
+{
+    "response_type": "normal",  # normal, error, delayed, empty, stray
+    "delay_by": <int>,
+    "data_len": <int>,
+    "error_code": <int>,
+    "clear_after": <int>,  # request count
+}
+```
+
+* `response_type` : Response expected from the server.
+  * `normal` : Normal response, no errors
+  * `error`: Return error responses , requires additional `error_code` field for the modbus error code to be returned.
+    * `error_code`: Error code to return, possible values are
+    * ```
+      0x01  # IllegalFunction
+      0x02  # IllegalAddress
+      0x03  # IllegalValue
+      0x04  # SlaveFailure
+      0x05  # Acknowledge
+      0x06  # SlaveBusy
+      0x08  # MemoryParityError
+      0x0A  # GatewayPathUnavailable
+      0x0B  # GatewayNoResponse
+
+      ```
+  * `delayed`: Responses are delayed by the time specified with `delay_by` field.
+    * `delay_by`: Delay the response by <n> seconds (`float`).
+  * `empty`: Returns an empty response or no response
+  * `stray`: Returns stray/junk response with length specified with `data_len` field.
+    * `data_len`: Length of the stray_data (`int`)
+  * `clear_after`: Clears the error responses after <n> requests (`int`)
+
+**EXAMPLES**
+
+**Return exception response 0x02 Illegal Address and clear after 5 requests**
+
+```
+curl -X POST http://localhost:8080 -d '{"response_type": "error", "error_code": 2, "clear_after": 5}'
+```
+
+**Return Empty response**
+
+```
+curl -X POST http://localhost:8080 -d '{"response_type": "empty"}'
+```
+
+**Return Stray response of length 25bytes**
+
+```
+curl -X POST http://localhost:8080 -d '{"response_type": "stray", "data_len": 25}'
+
+```
+
+**Delay responses by 3 seconds**
+
+```
+curl -X POST http://localhost:8080 -d '{"response_type": "delayed", "delay_by": 3}'
+
+```
+
+**Rever to normal responses**
+
+```
+curl -X POST http://localhost:8080 -d '{"response_type": "normal"}'
+
+```
+
+## TODO
+
+* Add REST Api endpoint to view current manipulator config.

--- a/pymodbus/repl/server/cli.py
+++ b/pymodbus/repl/server/cli.py
@@ -104,7 +104,7 @@ def print_help():
     print_formatted_text(HTML("<u>Available commands:</u>"))
     for cmd, hlp in sorted(COMMAND_HELPS.items()):
         print_formatted_text(
-            HTML("<skyblue>{cmd:45s}</skyblue><seagreen>{hlp:100s}</seagreen>")
+            HTML(f"<skyblue>{cmd:45s}</skyblue><seagreen>{hlp:100s}</seagreen>")
         )
 
 

--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -163,8 +163,8 @@ def run(
     else:
         modbus_config = DEFAULT_CONFIG
 
+    data_block_settings = modbus_config.pop("data_block_settings", {})
     modbus_config = modbus_config.get(modbus_server, {})
-
     if modbus_server != "serial":
         modbus_port = int(modbus_port)
         handler = modbus_config.pop("handler", "ModbusConnectedRequestHandler")
@@ -181,6 +181,7 @@ def run(
         unit=modbus_unit_id,
         loop=loop,
         single=False,
+        data_block_settings=data_block_settings,
         **web_app_config,
         **modbus_config,
     )

--- a/pymodbus/repl/server/main.py
+++ b/pymodbus/repl/server/main.py
@@ -186,13 +186,10 @@ def run(
         **modbus_config,
     )
     try:
+        loop.run_until_complete(app.run_async(repl))
         if repl:
-            loop.run_until_complete(app.run_async())
-
             loop.run_until_complete(run_repl(app))
-            loop.run_forever()
-        else:
-            app.run()
+        loop.run_forever()
 
     except CANCELLED_ERROR:
         print("Done!!!!!")

--- a/pymodbus/server/reactive/default_config.json
+++ b/pymodbus/server/reactive/default_config.json
@@ -1,32 +1,67 @@
 {
   "tcp": {
-    "handler": "ModbusConnectedRequestHandler",
-    "allow_reuse_address": true,
-    "allow_reuse_port": true,
-    "backlog": 20,
-    "ignore_missing_slaves": false
-  },
-  "rtu": {
-    "handler": "ModbusSingleRequestHandler",
-    "stopbits": 1,
-    "bytesize": 8,
-    "parity": "N",
-    "baudrate": 9600,
-    "timeout": 3,
-    "auto_reconnect": false,
-    "reconnect_delay": 2
-  },
-  "tls": {
-    "handler": "ModbusConnectedRequestHandler",
-    "certfile": null,
-    "keyfile": null,
-    "allow_reuse_address": true,
-    "allow_reuse_port": true,
-    "backlog": 20,
-    "ignore_missing_slaves": false
-  },
-  "udp": {
-    "handler": "ModbusDisonnectedRequestHandler",
-    "ignore_missing_slaves": false
-  }
+        "handler": "ModbusConnectedRequestHandler",
+        "allow_reuse_address": true,
+        "allow_reuse_port": true,
+        "backlog": 20,
+        "ignore_missing_slaves": false
+    },
+    "serial": {
+        "handler": "ModbusSingleRequestHandler",
+        "stopbits": 1,
+        "bytesize": 8,
+        "parity": "N",
+        "baudrate": 9600,
+        "timeout": 3,
+        "auto_reconnect": false,
+        "reconnect_delay": 2
+    },
+    "tls": {
+        "handler": "ModbusConnectedRequestHandler",
+        "certfile": null,
+        "keyfile": null,
+        "allow_reuse_address": true,
+        "allow_reuse_port": true,
+        "backlog": 20,
+        "ignore_missing_slaves": false
+    },
+    "udp": {
+        "handler": "ModbusDisonnectedRequestHandler",
+        "ignore_missing_slaves": false
+    },
+    "data_block_settings": {
+        "min_binary_value": 0,
+        "max_binary_value": 1,
+        "min_register_value": 0,
+        "max_register_value": 100,
+        "data_block": {
+            "discrete_inputs": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": false
+            },
+            "coils": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": false
+            },
+            "holding_registers": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": false
+            },
+            "input_registers": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": false
+            }
+
+        }
+
+
+    }
 }

--- a/pymodbus/server/reactive/default_config.py
+++ b/pymodbus/server/reactive/default_config.py
@@ -1,6 +1,6 @@
 """Configuration for Pymodbus REPL Reactive Module."""
 
-DEFAULT_CONFIG = {  # pylint: disable=consider-using-namedtuple-or-dataclass
+DEFAULT_CONFIG = {
     "tcp": {
         "handler": "ModbusConnectedRequestHandler",
         "allow_reuse_address": True,
@@ -31,4 +31,38 @@ DEFAULT_CONFIG = {  # pylint: disable=consider-using-namedtuple-or-dataclass
         "handler": "ModbusDisonnectedRequestHandler",
         "ignore_missing_slaves": False,
     },
+    "data_block_settings": {
+        "min_binary_value": 0,  # For coils and DI
+        "max_binary_value": 1,  # For coils and DI
+        "min_register_value": 0,  # For Holding and input registers
+        "max_register_value": 65535,  # For Holding and input registers
+        "data_block": {
+            "discrete_inputs": {
+                "block_start": 0,  # Block start
+                "block_size": 100,  # Block end
+                "default": 0,  # Default value,
+                "sparse": False,
+            },
+            "coils": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": False,
+            },
+            "holding_registers": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": False,
+            },
+            "input_registers": {
+                "block_start": 0,
+                "block_size": 100,
+                "default": 0,
+                "sparse": False,
+            },
+        },
+    },
 }
+
+__all__ = ["DEFAULT_CONFIG"]

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -244,6 +244,7 @@ class ReactiveServer:
                 )
 
             logger.info("Modbus server started")
+
         except Exception as exc:  # pylint: disable=broad-except
             logger.error("Error starting modbus server")
             logger.error(exc)
@@ -328,22 +329,19 @@ class ReactiveServer:
             skip_encoding = True
         return response, skip_encoding
 
-    def run(self):
+    async def run_async(self, repl_mode=False):
         """Run Web app."""
 
-        def _info(message):
-            msg = HINT.format(message, self._host, self._port)
-            print(msg)
-            # print(message)
-
-        web.run_app(self._web_app, host=self._host, port=self._port, print=_info)
-
-    async def run_async(self):
-        """Run Web app."""
         try:
             await self._runner.setup()
             site = web.TCPSite(self._runner, self._host, self._port)
             await site.start()
+            if not repl_mode:
+                message = (
+                    f"======== Running on http://{self._host}:{self._port} ========"
+                )
+                msg = HINT.format(message, self._host, self._port)
+                print(msg)
         except Exception as exc:  # pylint: disable=broad-except
             logger.error(exc)
 

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -164,9 +164,7 @@ class ReactiveModbusSlaveContext(ModbusSlaveContext):
         _block_type = self.decode(fc_as_hex)
         if self._randomize > 0 and _block_type in {"d", "i"}:
             with self._lock:
-                if (
-                    self._read_counter.get(_block_type) % self._randomize == 0
-                ):  # pylint: disable = compare-to-zero
+                if not (self._read_counter.get(_block_type) % self._randomize):
                     # Update values
                     if _block_type == "d":
                         min_val = self._min_binary_value

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -9,6 +9,7 @@ import sys
 import time
 from enum import Enum
 
+
 try:
     from aiohttp import web
 except ImportError:

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -7,7 +7,7 @@ import os
 import random
 import sys
 import time
-
+from enum import Enum
 
 try:
     from aiohttp import web
@@ -368,6 +368,9 @@ class ReactiveServer:
         :              refer corresponding servers documentation
         :return: ReactiveServer object
         """
+        if isinstance(server, Enum):
+            server = server.value
+
         if server.lower() not in SERVER_MAPPER:
             txt = f"Invalid server {server}"
             logger.error(txt)

--- a/pymodbus/server/reactive/main.py
+++ b/pymodbus/server/reactive/main.py
@@ -1,4 +1,6 @@
 """Reactive main."""
+from __future__ import annotations
+
 import asyncio
 import logging
 
@@ -6,6 +8,7 @@ import logging
 import os
 import random
 import sys
+import threading
 import time
 from enum import Enum
 
@@ -21,6 +24,7 @@ except ImportError:
 
 from pymodbus.datastore import ModbusServerContext, ModbusSlaveContext
 from pymodbus.datastore.store import (
+    BaseModbusDataBlock,
     ModbusSequentialDataBlock,
     ModbusSparseDataBlock,
 )
@@ -74,7 +78,12 @@ DEFUALT_HANDLERS = {
     "ModbusConnectedRequestHandler": ModbusConnectedRequestHandler,
     "ModbusDisconnectedRequestHandler": ModbusDisconnectedRequestHandler,
 }
-DEFAULT_MODBUS_MAP = {"start_offset": 0, "count": 100, "value": 0, "sparse": False}
+DEFAULT_MODBUS_MAP = {
+    "block_start": 0,
+    "block_size": 100,
+    "default": 0,
+    "sparse": False,
+}
 DEFAULT_DATA_BLOCK = {
     "co": DEFAULT_MODBUS_MAP,
     "di": DEFAULT_MODBUS_MAP,
@@ -91,6 +100,87 @@ Example Usage:
 curl -X POST http://{}:{} -d "{{"response_type": "error", "error_code": 4}}"
 ===========================================================================
 """
+
+
+class ReactiveModbusSlaveContext(ModbusSlaveContext):
+    """Reactive Modbus slave context"""
+
+    def __init__(
+        self,
+        discrete_inputs: BaseModbusDataBlock = None,
+        coils: BaseModbusDataBlock = None,
+        input_registers: BaseModbusDataBlock = None,
+        holding_registers: BaseModbusDataBlock = None,
+        zero_mode: bool = False,
+        randomize: int = 0,
+        **kwargs,
+    ):
+        """Reactive Modbus slave context supporting simulating data.
+
+        :param discrete_inputs: Discrete input data block
+        :param coils: Coils data block
+        :param input_registers: Input registers data block
+        :param holding_registers: Holding registers data block
+        :param zero_mode: Enable zero mode for data blocks
+        :param randomize: Randomize reads every <n> reads for DI and IR,
+                          default is disabled (0)
+        :param min_binary_value: Minimum value for coils and discrete inputs
+        :param max_binary_value: Max value for discrete inputs
+        :param min_register_value: Minimum value for input registers
+        :param max_register_value: Max value for input registers
+
+        """
+        super().__init__(
+            di=discrete_inputs,
+            co=coils,
+            ir=input_registers,
+            hr=holding_registers,
+            zero_mode=zero_mode,
+        )
+        min_binary_value = kwargs.get("min_binary_value", 0)
+        max_binary_value = kwargs.get("max_binary_value", 1)
+        min_register_value = kwargs.get("min_register_value", 0)
+        max_register_value = kwargs.get("max_register_value", 65535)
+        self._randomize = randomize
+        self._lock = threading.Lock()
+        self._read_counter = {"d": 0, "i": 0}
+        self._min_binary_value = min_binary_value
+        self._max_binary_value = max_binary_value
+        self._min_register_value = min_register_value
+        self._max_register_value = max_register_value
+
+    def getValues(self, fc_as_hex, address, count=1):
+        """Get `count` values from datastore.
+
+        :param fc_as_hex: The function we are working with
+        :param address: The starting address
+        :param count: The number of values to retrieve
+        :returns: The requested values from a:a+c
+        """
+        if not self.zero_mode:
+            address = address + 1
+        txt = f"getValues: fc-[{fc_as_hex}] address-{address}: count-{count}"
+        logger.debug(txt)
+        _block_type = self.decode(fc_as_hex)
+        if self._randomize > 0 and _block_type in {"d", "i"}:
+            with self._lock:
+                if (
+                    self._read_counter.get(_block_type) % self._randomize == 0
+                ):  # pylint: disable = compare-to-zero
+                    # Update values
+                    if _block_type == "d":
+                        min_val = self._min_binary_value
+                        max_val = self._max_binary_value
+                    else:
+                        min_val = self._min_register_value
+                        max_val = self._max_register_value
+                    values = [random.randint(min_val, max_val) for _ in range(count)]
+                    # logger.debug("Updating '%s' with values '%s' starting at "
+                    #              "'%s'", _block_type, values, address)
+                    self.store[_block_type].setValues(address, values)
+                self._read_counter[_block_type] += 1
+        values = self.store[_block_type].getValues(address, count)
+        return values
 
 
 class ReactiveServer:
@@ -294,25 +384,30 @@ class ReactiveServer:
 
     @classmethod
     def create_context(
-        cls, data_block=None, unit=[1], single=False
+        cls,
+        data_block_settings: dict = {},
+        unit: list[int] = [1],
+        single: bool = False,
+        randomize: int = 0,
     ):  # pylint: disable=dangerous-default-value
         """Create Modbus context.
 
-        :param data_block: Datablock (dict) Refer DEFAULT_DATA_BLOCK
+        :param data_block_settings: Datablock (dict) Refer DEFAULT_DATA_BLOCK
         :param unit: Unit id for the slave
         :param single: To run as a single slave
+        :param randomize: Randomize every <n> reads for DI and IR.
         :return: ModbusServerContext object
         """
-        data_block = data_block or DEFAULT_DATA_BLOCK
+        data_block = data_block_settings.pop("data_block", DEFAULT_DATA_BLOCK)
         if not isinstance(unit, list):
             unit = [unit]
         slaves = {}
         for i in unit:
             block = {}
             for modbus_entity, block_desc in data_block.items():
-                start_address = block_desc.get("start_address", 0)
-                default_count = block_desc.get("count", 0)
-                default_value = block_desc.get("value", 0)
+                start_address = block_desc.get("block_start", 0)
+                default_count = block_desc.get("block_size", 0)
+                default_value = block_desc.get("default", 0)
                 default_values = [default_value] * default_count
                 sparse = block_desc.get("sparse", False)
                 db = ModbusSequentialDataBlock if not sparse else ModbusSparseDataBlock
@@ -330,7 +425,9 @@ class ReactiveServer:
                 else:
                     block[modbus_entity] = db(start_address, default_values)
 
-            slave_context = ModbusSlaveContext(**block, zero_mode=True)
+            slave_context = ReactiveModbusSlaveContext(
+                **block, randomize=randomize, zero_mode=True, **data_block_settings
+            )
             if not single:
                 slaves[i] = slave_context
             else:
@@ -349,7 +446,7 @@ class ReactiveServer:
         host="localhost",
         modbus_port=5020,
         web_port=8080,
-        data_block=DEFAULT_DATA_BLOCK,
+        data_block_settings={"data_block": DEFAULT_DATA_BLOCK},
         identity=None,
         **kwargs,
     ):
@@ -363,7 +460,7 @@ class ReactiveServer:
         :param host: Host address to use for both web app and modbus server (default localhost)
         :param modbus_port: Modbus port for TCP and UDP server(default: 5020)
         :param web_port: Web App port (default: 8080)
-        :param data_block: Datablock (refer DEFAULT_DATA_BLOCK)
+        :param data_block_settings: Datablock settings (refer DEFAULT_DATA_BLOCK)
         :param identity: Modbus identity object
         :param kwargs: Other server specific keyword arguments,
         :              refer corresponding servers documentation
@@ -377,11 +474,15 @@ class ReactiveServer:
             logger.error(txt)
             sys.exit(1)
         server = SERVER_MAPPER.get(server)
+        randomize = kwargs.pop("randomize", 0)
         if not framer:
             framer = DEFAULT_FRAMER.get(server)
         if not context:
             context = cls.create_context(
-                data_block=data_block, unit=unit, single=single
+                data_block_settings=data_block_settings,
+                unit=unit,
+                single=single,
+                randomize=randomize,
             )
         if not identity:
             identity = cls.create_identity()


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
* Fix `--random` in `pymodbus.server` to randomize values read for `discrete inputs` and `input registers`
<img width="893" alt="image" src="https://user-images.githubusercontent.com/9276974/197694728-1533b5f6-3cbb-468a-b91d-79977ee42058.png">

Example invocation
```
pymodbus.server --verbose run  --modbus-server tcp --modbus-framer socket --modbus-port 5020 --unit-id 1 --unit-id 2 -u 4 -r 1 --timeout 2
```

The values for simulation can also be passed as a json file to `--modbus-config` param , for e.g to limit the max and min values a register should have. Refer `data_block_settings` in the below json file.

```
{
  "tcp": {
        "handler": "ModbusConnectedRequestHandler",
        "allow_reuse_address": true,
        "allow_reuse_port": true,
        "backlog": 20,
        "ignore_missing_slaves": false
    },
    "serial": {
        "handler": "ModbusSingleRequestHandler",
        "stopbits": 1,
        "bytesize": 8,
        "parity": "N",
        "baudrate": 9600,
        "timeout": 3,
        "auto_reconnect": false,
        "reconnect_delay": 2
    },
    "tls": {
        "handler": "ModbusConnectedRequestHandler",
        "certfile": null,
        "keyfile": null,
        "allow_reuse_address": true,
        "allow_reuse_port": true,
        "backlog": 20,
        "ignore_missing_slaves": false
    },
    "udp": {
        "handler": "ModbusDisonnectedRequestHandler",
        "ignore_missing_slaves": false
    },
    "data_block_settings": {
        "min_binary_value": 0,
        "max_binary_value": 1,
        "min_register_value": 0,
        "max_register_value": 100,
        "data_block": {
            "discrete_inputs": {
                "block_start": 0,
                "block_size": 100,
                "default": 0,
                "sparse": false
            },
            "coils": {
                "block_start": 0,
                "block_size": 100,
                "default": 0,
                "sparse": false
            },
            "holding_registers": {
                "block_start": 0,
                "block_size": 100,
                "default": 0,
                "sparse": false
            },
            "input_registers": {
                "block_start": 0,
                "block_size": 100,
                "default": 0,
                "sparse": false
            }

        }


    }
}
```

# TODO

- [ ] Update unit tests
- [x] Update documentation
