### PR TITLE
Improve Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 # syntax=docker/dockerfile:1
 
-FROM python:3.8-slim-buster
+FROM python:3.9-slim-buster
 
 WORKDIR /pymodbus
 
+EXPOSE 8080
+EXPOSE 5020
+
 COPY . .
 
-RUN pip3 install -r requirements.txt && pip3 install -e .
+RUN pip install -r requirements.txt && pip install -e .
 
+CMD [ "pymodbus.server", "--host", "127.0.0.1", "--web-port", "8080", "--no-repl", "run", "--modbus-port", "5020", "--modbus-server", "tcp" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,6 @@ EXPOSE 5020
 
 COPY . .
 
-RUN pip install -r requirements.txt && pip install -e .
+RUN pip3 install -r requirements.txt && pip3 install -e .
 
 CMD [ "pymodbus.server", "--host", "127.0.0.1", "--web-port", "8080", "--no-repl", "run", "--modbus-port", "5020", "--modbus-server", "tcp" ]

--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,14 @@ Or to install a specific release:
 You can also use Docker to run a local image with the package installed on the image:
 
     docker pull riptideio/pymodbus
+   
+To run this, you will need to expose ports 8080 and 5020, you can the container running:
+
+    docker run -it -p 8080:8080 -p 5020:502 riptideio/pymodbus
+
+You can also override the default command running the server with any of the examples:
+
+    docker run -it -p 8080:8080 -p 5020:502 riptideio/pymodbus examples/server_sync.py
 
 Otherwise you can pull the trunk source and install from there::
 


### PR DESCRIPTION
# What?

Improve docker support by adding a default working CMD instruction.

By default tries to run the modbus server in a headless mode.

Additionally, adding a bit more details to the documentation

# Why?

This makes the container more useful and friendly. It becomes ready to use with no much more to do.

# Proof it's working

<img width="843" alt="image" src="https://user-images.githubusercontent.com/1817347/198166463-35311050-07a5-4757-8f88-eed9fae3ddd1.png">
