### PR TITLE
Avoid unwanted reconnects

### DIFF
--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -67,13 +67,12 @@ class AsyncModbusTcpClient(ModbusBaseClient):
 
     async def close(self):  # pylint: disable=invalid-overridden-method
         """Stop client."""
-        
+
         # prevent reconnect.
         self.params.host = None
-        
+
         if self.connected and self.protocol and self.protocol.transport:
             self.protocol.transport.close()
-
 
     def _create_protocol(self):
         """Create initialized protocol instance with factory function."""

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -67,11 +67,13 @@ class AsyncModbusTcpClient(ModbusBaseClient):
 
     async def close(self):  # pylint: disable=invalid-overridden-method
         """Stop client."""
+        
+        # prevent reconnect.
+        self.params.host = None
+        
         if self.connected and self.protocol and self.protocol.transport:
             self.protocol.transport.close()
 
-        # prevent reconnect.
-        self.params.host = None
 
     def _create_protocol(self):
         """Create initialized protocol instance with factory function."""


### PR DESCRIPTION
Fixes a possible race condition resulting in an unwanted reconnect due to `protocol_lost_connection` that would do a reconnect if `params.host` is still filled in right after doing the disconnect of the protocol-class.

The order of these statements is already ok in `udp.py`.