### PR TITLE
Do not install run dependencies for linters

### DIFF
--- a/bandit.yaml
+++ b/bandit.yaml
@@ -1,5 +1,9 @@
 # https://bandit.readthedocs.io/en/latest/config.html
-
+exclude_dirs:
+  - doc
+  - .venv
+  - .git
+  - .tox
 tests:
   - B103
   - B108

--- a/setup.cfg
+++ b/setup.cfg
@@ -476,8 +476,7 @@ check-str-concat-over-line-jumps=no
 #max-line-length-suggestions=
 
 [flake8]
-exclude         = .venv,.git,.tox,venv,build,tornado_twisted,examples/contrib/libmodbus_client.py
-max-complexity  = 25
+exclude         = .venv,.git,.tox,venv,doc,build,examples/v2.5.3
 doctests        = True
 max-line-length = 120
 # To work with Black
@@ -540,7 +539,12 @@ omit =
     examples/common/tornado_twister
     examples/contrib/tornado_twister
 
+[codespell]
+skip=doc,.venv,.git,.tox,CHANGELOG.rst
+ignore-words-list = asend
+
 [isort]
+skip=doc,.venv,.git,.tox
 py_version=38
 profile=black
 line_length = 79

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,14 @@
 # --------------------------------------------------------------------------- #
 # initialization
 # --------------------------------------------------------------------------- #
-from setuptools import find_packages, setup
+from setuptools import setup
+
+
 try:
     from setup_commands import command_classes
 except ImportError:
     command_classes = {}
-from pymodbus import __author__, __maintainer__, __version__
+
 
 dependencies = {}
 with open('requirements.txt') as reqs:

--- a/setup_commands.py
+++ b/setup_commands.py
@@ -5,6 +5,7 @@ import sys
 
 from setuptools import Command
 
+
 # --------------------------------------------------------------------------- #
 # Extra Commands
 # --------------------------------------------------------------------------- #
@@ -107,20 +108,11 @@ class LintCommand(Command):
         except Exception:
             return False
 
-    def _try_pychecker(self):
-        try:
-            import pychecker
-            sys.argv = """pychecker pymodbus/*.py""".split()
-            main()
-            return True
-        except Exception:
-            return False
-
     def _try_pylint(self):
         try:
             import pylint
             sys.argv = """pylint pymodbus/*.py""".split()
-            main()
+            pylint.main()
             return True
         except Exception:
             return False

--- a/tox.ini
+++ b/tox.ini
@@ -21,48 +21,56 @@ setenv =
 [testenv:pylint]
 deps = -r requirements.txt
 ignore_errors = false
+skipsdist = true
 commands =
     pylint --recursive=y examples pymodbus test
 
 [testenv:codespell]
-deps = -r requirements.txt
+deps = codespell
 ignore_errors = false
+skipsdist = true
 commands =
     codespell --ignore-words-list asend --skip="_build" examples pymodbus test
 
 [testenv:isort]
-deps = -r requirements.txt
+deps = isort
 ignore_errors = false
+skipsdist = true
 commands =
     isort examples pymodbus test
 
 [testenv:isort_CI]
-deps = -r requirements.txt
+deps = isort
 ignore_errors = false
+skipsdist = true
 commands =
     isort --check examples pymodbus test
 
 [testenv:bandit]
-deps = -r requirements.txt
+deps = bandit
 ignore_errors = false
+skipsdist = true
 commands =
     bandit -r -c bandit.yaml examples/ pymodbus/ test/
 
 [testenv:flake8]
-deps = -r requirements.txt
+deps = flake8
 ignore_errors = false
+skipsdist = true
 commands =
     flake8 examples/ pymodbus/ test/
 
 [testenv:black]
-deps = -r requirements.txt
+deps = black
 ignore_errors = false
+skipsdist = true
 commands =
     black --safe --quiet examples/ pymodbus/ test/
 
 [testenv:black_CI]
-deps = -r requirements.txt
+deps = black
 ignore_errors = false
+skipsdist = true
 commands =
     black --check --safe --quiet examples/ pymodbus/ test/
 

--- a/tox.ini
+++ b/tox.ini
@@ -30,35 +30,35 @@ deps = codespell
 ignore_errors = false
 skipsdist = true
 commands =
-    codespell --ignore-words-list asend --skip="_build" examples pymodbus test
+    codespell
 
 [testenv:isort]
 deps = isort
 ignore_errors = false
 skipsdist = true
 commands =
-    isort examples pymodbus test
+    isort .
 
 [testenv:isort_CI]
 deps = isort
 ignore_errors = false
 skipsdist = true
 commands =
-    isort --check examples pymodbus test
+    isort --check .
 
 [testenv:bandit]
 deps = bandit
 ignore_errors = false
 skipsdist = true
 commands =
-    bandit -r -c bandit.yaml examples/ pymodbus/ test/
+    bandit -r -c bandit.yaml .
 
 [testenv:flake8]
 deps = flake8
 ignore_errors = false
 skipsdist = true
 commands =
-    flake8 examples/ pymodbus/ test/
+    flake8
 
 [testenv:black]
 deps = black


### PR DESCRIPTION
The current CI takes a long time (~40 mins of GH Actions runtime).  Although it's free and parallelized I think this could still be improved.

`tox` is a tool for code testing, but it's overkill for linting source code with e.g. black, codespell...  I've simplified the install for each linter to just its own package.  (It may be best to use a simpler action to just do `git checkout` + run the linter, but I don't want to make too major changes. )

This significantly improves the linter runtimes:
- pylint broke so I left it alone :P
- codespell -> 60% faster
- bandit -> 50% faster
- flake8 -> 60% faster
- isort -> 40% faster
- black -> 20% faster  
