### PR TITLE
Serial receive incomplete bytes.issue#1183

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -304,6 +304,8 @@ class ModbusSerialClient(ModbusBaseClient):
             )
         if size is None:
             size = self._wait_for_data()
+        elif size > self._in_waiting():
+            self._wait_for_data()
         result = self.socket.read(size)
         return result
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -83,10 +83,12 @@ class mockSocket:  # pylint: disable=invalid-name
     def __init__(self):
         """Initialize."""
         self.data = None
+        self.in_waiting = 0
 
     def mock_store(self, msg):
         """Store message."""
         self.data = msg
+        self.in_waiting = len(self.data)
 
     def mock_retrieve(self, size):
         """Get message."""
@@ -97,6 +99,7 @@ class mockSocket:  # pylint: disable=invalid-name
         else:
             retval = self.data[0:size]
         self.data = None
+        self.in_waiting = 0
         return retval
 
     def close(self):

--- a/test/test_client_sync.py
+++ b/test/test_client_sync.py
@@ -476,13 +476,11 @@ class SynchronousClientTest(
         self.assertEqual(b"", client.recv(0))
         client.socket.mock_store(b"\x00" * 4)
         self.assertEqual(b"\x00" * 4, client.recv(4))
-        client.socket = MagicMock()
-        client.socket.read.return_value = b""
+        client.socket = mockSocket()
+        client.socket.mock_store(b"")
         self.assertEqual(b"", client.recv(None))
         client.socket.timeout = 0
         self.assertEqual(b"", client.recv(0))
-        client.params.timeout = None
-        self.assertEqual(b"", client.recv(None))
 
     def test_serial_client_repr(self):
         """Test serial client."""


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
In function recv of pymodbus/client/serial.py, when size if not None, serial does not wait data.

fixes #1183