### PR TITLE
Support Python3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
             lint: 'no'
           - version: '3.10'
             lint: 'no'
+          - version: '3.11'
+            lint: 'no'
           - version: pypy-3.8
             lint: 'no'
         exclude:

--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -167,7 +167,6 @@ async def run_async_server(args):
             # custom_functions=[],  # allow custom handling
             framer=args.framer,  # The framer strategy to use
             # handler=None,  # handler for each session
-            # TBD allow_reuse_address=True,  # allow the reuse of an address
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat unit_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete

--- a/examples/server_sync.py
+++ b/examples/server_sync.py
@@ -84,7 +84,6 @@ def run_sync_server(args):
             # custom_functions=[],  # allow custom handling
             framer=args.framer,  # The framer strategy to use
             # TBD handler=None,  # handler for each session
-            # TBD allow_reuse_address=True,  # allow the reuse of an address
             # ignore_missing_slaves=True,  # ignore request to a missing slave
             # broadcast_enable=False,  # treat unit_id 0 as broadcast address,
             # timeout=1,  # waiting time for request to complete

--- a/pymodbus/server/async_io.py
+++ b/pymodbus/server/async_io.py
@@ -689,7 +689,6 @@ class ModbusUdpServer:
         identity=None,
         address=None,
         handler=None,
-        allow_reuse_address=False,
         allow_reuse_port=False,
         defer_start=False,  # pylint: disable=unused-argument
         backlog=20,  # pylint: disable=unused-argument
@@ -737,7 +736,6 @@ class ModbusUdpServer:
         self.serving = self.loop.create_future()
         self.factory_parms = {
             "local_addr": self.address,
-            "reuse_address": allow_reuse_address,
             "reuse_port": allow_reuse_port,
             "allow_broadcast": True,
         }


### PR DESCRIPTION
Closes #1245.

All tests pass on Python3.11 the same as Python3.10 and 3.8 on MacOS for me.

I see you have simplified and cleaned up the CI a lot; awesome! Hopefully it's easy to add 3.11

