### PR TITLE
Parallelize pytest with pytest-xdist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
             cmd: make -C doc/ html
             type: lint
           - name: pytest
-            cmd: pytest --cov=pymodbus --cov=test --cov-report=term-missing --cov-report=xml -v --full-trace --timeout=20
+            cmd: pytest --cov=pymodbus --cov=test --cov-report=term-missing --cov-report=xml -v --full-trace --timeout=20 --numprocesses auto
             type: test
         os:
           - name: Linux

--- a/check_ci.sh
+++ b/check_ci.sh
@@ -10,5 +10,5 @@ black --safe --quiet examples/ pymodbus/ test/
 isort .
 pylint --recursive=y examples pymodbus test
 flake8
-pytest
+pytest --numprocesses auto
 echo "Ready to push"

--- a/requirements.txt
+++ b/requirements.txt
@@ -70,3 +70,4 @@ pytest==7.1.3
 pytest-asyncio==0.19.0
 pytest-cov==4.0.0
 pytest-timeout==2.1.0
+pytest-xdist==3.1.0


### PR DESCRIPTION
Consider adding this requirement for `pytest-xdist` to speed up pytest runs by running them [in 
parallel](https://pytest-xdist.readthedocs.io/en/latest/distribution.html).

Pros:
+50% speedup on my laptop

Cons:
- Extra dependency
- Pytest output does not list individual tests any more

```
collected 417 items

test/test_all_messages.py ...                                                                              [  0%]
test/test_bit_read_messages.py .........                                                                   [  2%]
test/test_bit_write_messages.py .........                                                                  [  5%]
test/test_client.py ............................................s.........                                 [ 17%]
test/test_client_sync.py .....
```
```
gw0 [417] / gw1 [417] / gw2 [417] / gw3 [417] / gw4 [417] / gw5 [417] / gw6 [417] / gw7 [417]
.......................................s.................................................................. [ 25%]
.......................................................................................................... [ 50%]
.......................................................................................................... [ 76%]
...................................................................................................        [100%]
```
