### PR TITLE
Document task cancellation brokenness

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -2,6 +2,10 @@ API changes
 ===========
 Versions (X.Y.Z) where Z > 0 e.g. 3.0.1 do NOT have API changes!
 
+API changes 3.8.7
+-----------------
+- Drop support for asyncio task cancellation
+
 API changes 3.8.0
 -----------------
 - ModbusSlaveContext, removed zero_mode parameter.

--- a/doc/source/client.rst
+++ b/doc/source/client.rst
@@ -10,6 +10,9 @@ The client is NOT thread safe, meaning the application must ensure that calls ar
 This is only a problem for synchronous applications that use multiple threads or for asynchronous applications
 that use multiple :mod:`asyncio.create_task`.
 
+The client no longer supports task cancellation, please don't use pymodbus with asyncio frameworks like aiohttp that rely on task cancellation.
+Note that pymodbus is deliberately NOT safe to use with code that relies on task cancellation.
+
 It is allowed to have multiple client objects that e.g. each communicate with a TCP based device.
 
 


### PR DESCRIPTION
Document the broken task cancellation behavior described [here](https://github.com/pymodbus-dev/pymodbus/pull/2584#issuecomment-2682693129) as being intentional.