### PR TITLE
Clarify documentation on reconnect_delay

### DIFF
--- a/pymodbus/client/serial.py
+++ b/pymodbus/client/serial.py
@@ -35,9 +35,9 @@ class AsyncModbusSerialClient(ModbusBaseClient):
     :param stopbits: Number of stop bits 1, 1.5, 2.
     :param handle_local_echo: Discard local echo from dongle.
     :param name: Set communication name, used in logging
-    :param reconnect_delay: Minimum delay before reconnecting, in seconds.
-    :param reconnect_delay_max: Maximum delay before reconnecting, in seconds.
-    :param timeout: Timeout for connecting and receiving data, in seconds.
+    :param reconnect_delay: Minimum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param reconnect_delay_max: Maximum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param timeout: Timeout for connecting and receiving data, in seconds (use decimals for milliseconds).
     :param retries: Max number of retries per request.
     :param trace_packet: Called with bytestream received/to be sent
     :param trace_pdu: Called with PDU received/to be sent

--- a/pymodbus/client/tcp.py
+++ b/pymodbus/client/tcp.py
@@ -28,9 +28,9 @@ class AsyncModbusTcpClient(ModbusBaseClient):
     :param port: Port used for communication
     :param name: Set communication name, used in logging
     :param source_address: source address of client
-    :param reconnect_delay: Minimum delay before reconnecting, in seconds.
-    :param reconnect_delay_max: Maximum delay before reconnecting, in seconds.
-    :param timeout: Timeout for connecting and receiving data, in seconds.
+    :param reconnect_delay: Minimum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param reconnect_delay_max: Maximum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param timeout: Timeout for connecting and receiving data, in seconds (use decimals for milliseconds).
     :param retries: Max number of retries per request.
     :param trace_packet: Called with bytestream received/to be sent
     :param trace_pdu: Called with PDU received/to be sent

--- a/pymodbus/client/tls.py
+++ b/pymodbus/client/tls.py
@@ -26,9 +26,9 @@ class AsyncModbusTlsClient(AsyncModbusTcpClient):
     :param port: Port used for communication
     :param name: Set communication name, used in logging
     :param source_address: Source address of client
-    :param reconnect_delay: Minimum delay before reconnecting, in seconds.
-    :param reconnect_delay_max: Maximum delay before reconnecting, in seconds.
-    :param timeout: Timeout for connecting and receiving data, in seconds.
+    :param reconnect_delay: Minimum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param reconnect_delay_max: Maximum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param timeout: Timeout for connecting and receiving data, in seconds (use decimals for milliseconds).
     :param retries: Max number of retries per request.
     :param trace_packet: Called with bytestream received/to be sent
     :param trace_pdu: Called with PDU received/to be sent

--- a/pymodbus/client/udp.py
+++ b/pymodbus/client/udp.py
@@ -29,9 +29,9 @@ class AsyncModbusUdpClient(ModbusBaseClient):
     :param port: Port used for communication.
     :param name: Set communication name, used in logging
     :param source_address: source address of client,
-    :param reconnect_delay: Minimum delay before reconnecting, in seconds.
-    :param reconnect_delay_max: Maximum delay before reconnecting, in seconds.
-    :param timeout: Timeout for connecting and receiving data, in seconds.
+    :param reconnect_delay: Minimum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param reconnect_delay_max: Maximum delay when reconnecting, in seconds (use decimals for milliseconds).
+    :param timeout: Timeout for connecting and receiving data, in seconds (use decimals for milliseconds).
     :param retries: Max number of retries per request.
     :param trace_packet: Called with bytestream received/to be sent
     :param trace_pdu: Called with PDU received/to be sent


### PR DESCRIPTION
A fix for #2768: the syntax of `seconds.milliseconds` just does not make sense. As the arguments are typed as floats it is clear that you can pass fractional values.