### PR TITLE
Remove possibility for projects like home-assistant to use 2 versions of pymodbus.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,30 +48,6 @@ Source code on `github <https://github.com/pymodbus-dev/pymodbus>`_
 
 Full documentation for newest releases as well as the bleeding edge (dev) `readthedocs <https://pymodbus.readthedocs.io>`_
 
-pymodbus is maintained in 2 versions:
-- pymodbus, the official library
-- pymodbus_ha_core
-
-Pymodbus_ha
------------
-**CURRENTLY IN DEVELOPMENT**
-
-`Pymodbus_ha <https://pypi.org/project/pymodbus-ha/>`_ is
-an alias to pymodbus, available on pypi.org.
-
-Being an alias means it is 100% the same as pymodbus, without any extra
-code, just different distribution and package names.
-
-The idea is to allow projects like e.g. home-assistant to use this library
-in the core, while custom parts uses the normal pymodbus. Doing so allows
-the core and the custom part to use different versions.
-
-Of course the decision to use the library or not, is left to each project,
-just like it is the project that decides whether or not to use pymodbus.
-
-Pymodbus can easily be extended with other aliases if needed. Please open
-an issue for a discussion if wanted.
-
 Pymodbus in a nutshell
 ----------------------
 Pymodbus consist of 5 parts:


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
The idea have been profoundly rejected by Home-assistant, including making it available for custom components.

A project can easily block this feature by pinning both pymodbus and the alias, so it does not make sense
for pymodbus to continue along this route.

We thank the participating custom projects for input and the alternative solution suggested
will be made available soon, without public announcements for obvious reasons.