### PR TITLE
Change ExceptionResponse for no_response_expected parameter.

### DIFF
--- a/API_changes.rst
+++ b/API_changes.rst
@@ -2,6 +2,10 @@ API changes
 ===========
 Versions (X.Y.Z) where Z > 0 e.g. 3.0.1 do NOT have API changes!
 
+API changes 3.12.0
+------------------
+- when using no_response_expected=, the call returns None
+
 API changes 3.11.0
 ------------------
 - Revert wrong byte handling in v3.10.0

--- a/examples/client_async_calls.py
+++ b/examples/client_async_calls.py
@@ -267,8 +267,7 @@ async def async_execute_diagnostic_requests(client):
     rr = await client.diag_getclear_modbus_response(device_id=DEVICE_ID)
     assert not rr.isError()  # test that call was OK
     rr = await client.diag_force_listen_only(device_id=DEVICE_ID, no_response_expected=True)
-    assert rr.isError()  # test that call was OK, error indicate no response
-
+    assert not rr
 
 # ------------------------
 # Run the calls in groups.

--- a/pymodbus/transaction/transaction.py
+++ b/pymodbus/transaction/transaction.py
@@ -8,7 +8,7 @@ from threading import RLock
 from pymodbus.exceptions import ConnectionException, ModbusIOException
 from pymodbus.framer import FramerAscii, FramerBase, FramerRTU
 from pymodbus.logging import Log
-from pymodbus.pdu import ExceptionResponse, ModbusPDU
+from pymodbus.pdu import ModbusPDU
 from pymodbus.transport import CommParams, ModbusProtocol
 
 
@@ -127,7 +127,7 @@ class TransactionManager(ModbusProtocol):
             while count_retries <= self.retries:
                 self.pdu_send(request)
                 if no_response_expected:
-                    return ExceptionResponse(0xff)
+                    return None  # type: ignore[return-value]
                 try:
                     response = self.sync_get_response(request.dev_id, request.transaction_id)
                     if response.dev_id != request.dev_id:
@@ -170,7 +170,7 @@ class TransactionManager(ModbusProtocol):
                 self.response_future = asyncio.Future()
                 self.pdu_send(request)
                 if no_response_expected:
-                    return ExceptionResponse(0xff)
+                    return None  # type: ignore[return-value]
                 try:
                     response = await asyncio.wait_for(
                         self.response_future, timeout=self.comm_params.timeout_connect

--- a/test/transaction/test_transaction.py
+++ b/test/transaction/test_transaction.py
@@ -314,8 +314,7 @@ class TestTransaction:
         transact.data_received(data)
         if no_resp:
             result = await resp
-            assert result.isError()
-            assert isinstance(result, ExceptionResponse)
+            assert not result
         else:
             with pytest.raises(ModbusIOException):
                 await resp
@@ -599,7 +598,7 @@ class TestSyncTransaction:
         transact.sync_client.send = mock.Mock()
         result = transact.sync_execute(no_resp, request)
         if no_resp:
-            assert result.isError()
+            assert not result
         else:
             assert not result.isError()
             assert isinstance(response, ReadCoilsResponse)


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
When making a request/call with no_response_expected=True, the call returns None

fixes #2800