### PR TITLE
Include ModbusSequentialDataBlock into the documentation

### DIFF
--- a/doc/source/library/datastore.rst
+++ b/doc/source/library/datastore.rst
@@ -7,6 +7,10 @@ Datastore is responsible for managing registers for a server.
 Datastore classes
 -----------------
 
+.. autoclass:: pymodbus.datastore.ModbusSequentialDataBlock
+    :members:
+    :member-order: bysource
+
 .. autoclass:: pymodbus.datastore.ModbusSparseDataBlock
     :members:
     :member-order: bysource


### PR DESCRIPTION
The documentation for ModbusSequentialDataBlock is missing in the online official documentation, I think it should be added.