### PR TITLE
ModbusServerContext.device_ids() docstring

### DIFF
--- a/pymodbus/datastore/context.py
+++ b/pymodbus/datastore/context.py
@@ -223,5 +223,5 @@ class ModbusServerContext:
         )
 
     def device_ids(self):
-        """Define device_ids."""
+        """Get the configured device ids."""
         return list(self._devices.keys())


### PR DESCRIPTION
According to [the following discussion ](https://github.com/pymodbus-dev/pymodbus/discussions/2834), the docstring has to be modified.

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
