### PR TITLE
Solve DoS vulnerability.

### DIFF
--- a/pymodbus/transport/transport.py
+++ b/pymodbus/transport/transport.py
@@ -329,6 +329,8 @@ class ModbusProtocol(asyncio.BaseProtocol):
             if not data:
                 return
         Log.transport_dump(Log.RECV_DATA, data, self.recv_buffer)
+        if len(self.recv_buffer) > 1024:
+            self.recv_buffer = b''
         self.recv_buffer += data
         cut = self.callback_data(self.recv_buffer, addr=addr)
         self.recv_buffer = self.recv_buffer[cut:]


### PR DESCRIPTION
An attack is only possible in a setup that goes against:
- the modbus standard (which states to use TLS on open connections)
- the pymodbus documentation (which states server is only for testing)

<!--  Please raise your PR's against the `dev` branch instead of `master` -->
