### PR TITLE
Docs/simulator official entrypoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -268,6 +268,14 @@ so that others can benefit from the results.
 
 `Example documentation <https://pymodbus.readthedocs.io/en/dev/source/examples.html>`_
 
+Ready to go simulator
+^^^^^^^^^^^^^^^^^^^^^
+To start the simulator and explore the Web UI, run the following command from the root directory::
+
+    python examples/simulator.py
+
+Once started, the Modbus server will listen on port 5020 and the Web UI will be available at http://localhost:8081.
+
 Troubleshooting the dev branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 If you encounter errors while running examples, please check:

--- a/README.rst
+++ b/README.rst
@@ -270,11 +270,21 @@ so that others can benefit from the results.
 
 Ready to go simulator
 ^^^^^^^^^^^^^^^^^^^^^
-To start the simulator and explore the Web UI, run the following command from the root directory::
+The simulator can be started directly using the installed entry point::
 
-    python examples/simulator.py
+    pymodbus.simulator --modbus_device device_try
 
-Once started, the Modbus server will listen on port 5020 and the Web UI will be available at http://localhost:8081.
+**Configuration Parameters:**
+
+To ensure the simulator starts with the correct data context, use the following flags:
+
+* ``--json_file``: Path to the configuration JSON (defaults to the internal ``setup.json``).
+* ``--modbus_server``: Selects the server type from the JSON ``server_list``.
+* ``--modbus_device``: Selects the device registers from the JSON ``device_list``.
+* ``--http_port``: Port for the Web UI (default: 8081).
+* ``--log``: Sets the log level (default: info).
+
+.. note:: Starting the simulator without explicit parameters may load an internal default configuration.
 
 Troubleshooting the dev branch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/simulator.py
+++ b/examples/simulator.py
@@ -82,13 +82,10 @@ async def run_simulator():
     _logger.info("### run calls")
     await run_calls(client, 1)
 
-    _logger.info("### shutdown client")
-    client.close()
-
-    _logger.info("### shutdown server")
-    await task.stop()
     _logger.info("### Thanks for now.")
 
-
+    _logger.info("### Simulator is ALIVE. Access Web UI at http://localhost:8081")
+    _logger.info("### Press Ctrl+C to stop.")
+    await asyncio.Event().wait()  
 if __name__ == "__main__":
     asyncio.run(run_simulator(), debug=True)

--- a/examples/simulator.py
+++ b/examples/simulator.py
@@ -82,10 +82,13 @@ async def run_simulator():
     _logger.info("### run calls")
     await run_calls(client, 1)
 
+    _logger.info("### shutdown client")
+    client.close()
+
+    _logger.info("### shutdown server")
+    await task.stop()
     _logger.info("### Thanks for now.")
 
-    _logger.info("### Simulator is ALIVE. Access Web UI at http://localhost:8081")
-    _logger.info("### Press Ctrl+C to stop.")
-    await asyncio.Event().wait()  
+
 if __name__ == "__main__":
     asyncio.run(run_simulator(), debug=True)


### PR DESCRIPTION
This PR addresses the documentation gap discussed in issue #2872. It clarifies the use of the official entry point for a persistent simulator experience.