### PR TITLE
fix: add warning log when using internal default simulator config

### DIFF
--- a/pymodbus/server/simulator/main.py
+++ b/pymodbus/server/simulator/main.py
@@ -98,6 +98,11 @@ def get_commandline(cmdline=None):
     )
     args = parser.parse_args(cmdline)
     pymodbus_apply_logging_config(args.log.upper())
+    # En main.py, dentro de get_commandline o run_main
+    default_json = os.path.join(os.path.dirname(__file__), "setup.json")
+    if args.json_file == default_json:
+        Log.warning("No custom configuration provided. Using internal default 'setup.json'.")
+        Log.warning("To interact with your own registers, please provide a JSON file using --json_file.")
     Log.info("Start simulator")
     cmd_args = {}
     for argument in args.__dict__:


### PR DESCRIPTION
## Description
Following up on the discussion in PR #2880 regarding simulator persistence and onboarding. 

While the simulator provides a great "zero-config" experience, starting it without a user-provided JSON file often leads to confusion when clients attempt to request data from non-existent registers. 

This PR adds a proactive warning in the entry point logic:
- Detects if the internal `setup.json` is being used as a fallback.
- Logs a `WARNING` indicating that a demo configuration is active.
- Provides explicit instructions on how to load a custom configuration using `--json_file`.

## Technical Changes
- Modified `pymodbus/server/simulator/main.py`: Added logic check in `get_commandline` after logging initialization to ensure the warning is formatted correctly according to the user's log level.

## Testing
-OS: Windows 11 Enterprise LTSC.

Shell: MINGW64 (Git Bash) / PowerShell Core.
  - Running `pymodbus.simulator` now correctly triggers the warning logs.
  - Running with a custom `--json_file` bypasses the warning as expected.
  
<img width="886" height="205" alt="image" src="https://github.com/user-attachments/assets/a7d04d54-e1c5-41f0-9358-97beb976e106" />
