### PR TITLE
fix: implement startup armouring and update 3.x docs

### DIFF
--- a/doc/source/library/simulator/config.rst
+++ b/doc/source/library/simulator/config.rst
@@ -5,6 +5,27 @@ Configuring the pymodbus simulator is done with a json file, or if only
 using the datastore simulator a python dict (same structure as the
 device part of the json file).
 
+
+Starting the Simulator
+----------------------
+
+The simulator is invoked via the command line entry point. The following parameters allow you to select your configuration and control the server behavior:
+
+* ``--json_file``: 
+    Path to the JSON configuration file. 
+    **Note:** The simulator will validate the existence of this file and fail to start with an error message if it is missing.
+* ``--modbus_server``: 
+    Selects which server configuration to load from the ``server_list``.
+* ``--modbus_device``: 
+    Selects which device registers to load from the ``device_list``.
+* ``--http_host`` / ``--http_port``: 
+    Defines the binding address and port for the Web UI (default port: 8081).
+* ``--log``: 
+    Sets the logging level (choices: critical, error, warning, info, debug).
+* ``--custom_actions_module``: 
+    Optional Python file for custom register behaviors.
+
+
 Json file layout
 ----------------
 

--- a/pymodbus/server/simulator/main.py
+++ b/pymodbus/server/simulator/main.py
@@ -105,6 +105,15 @@ def get_commandline(cmdline=None):
             continue
         if args.__dict__[argument] is not None:
             cmd_args[argument] = args.__dict__[argument]
+        if not os.path.exists(args.json_file):
+        # Configuramos un log básico para asegurar que el error fatal sea visible
+            pymodbus_apply_logging_config("ERROR") 
+            Log.error(f"FATAL: Configuration file '{args.json_file}' not found.")
+            Log.error("The simulator cannot start without a valid configuration file.")
+            Log.error("Please provide a path with --json_file or ensure setup.json exists.")
+            import sys
+            sys.exit(1)
+
     return cmd_args
 
 


### PR DESCRIPTION
This PR implements the 'armouring' we discussed and updates the official documentation path.

Code: Added a check in pymodbus/server/simulator/main.py to ensure the configuration file exists. The simulator now fails with a clear FATAL error instead of a silent empty start.*

Documentation: Updated doc/source/library/simulator/config.rst (3.x path) with a new technical reference for command-line parameters.*

This replaces the need for local README files, keeping the package source clean