### PR TITLE
Fix Read Fifo Query  RTU Frame Size

### DIFF
--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -260,7 +260,7 @@ class ReadFifoQueueResponse(ModbusPDU):
         """Calculate the size of the message."""
         hi_byte = int(data[2])
         lo_byte = int(data[3])
-        return ((hi_byte << 16) + lo_byte) * 2 + 6
+        return ((hi_byte << 16) + lo_byte) + 6
 
     def __init__(self, values: list[int] | None = None, dev_id: int = 1, transaction_id:int  = 0) -> None:
         """Initialize a new instance."""

--- a/pymodbus/pdu/file_message.py
+++ b/pymodbus/pdu/file_message.py
@@ -260,7 +260,7 @@ class ReadFifoQueueResponse(ModbusPDU):
         """Calculate the size of the message."""
         hi_byte = int(data[2])
         lo_byte = int(data[3])
-        return ((hi_byte << 16) + lo_byte) + 6
+        return ((hi_byte << 16) + lo_byte) + 4
 
     def __init__(self, values: list[int] | None = None, dev_id: int = 1, transaction_id:int  = 0) -> None:
         """Initialize a new instance."""

--- a/test/pdu/test_file_message.py
+++ b/test/pdu/test_file_message.py
@@ -61,7 +61,7 @@ class TestBitMessage:
     def test_frame_size(self):
         """Test that the read fifo queue response can decode."""
         message = TEST_MESSAGE
-        result = ReadFifoQueueResponse.calculateRtuFrameSize(message)
+        result = ReadFifoQueueResponse.calculateRtuFrameSize(b"\x00\x18" + message)
         assert result == 14
 
     # -----------------------------------------------------------------------#


### PR DESCRIPTION
Found a small calculation error in the Read FIFO Query function.
This should fix it, unless a test fails again.