### PR TITLE
Fix usage docs in examples: add missing option --baudrate

### DIFF
--- a/examples/server_async.py
+++ b/examples/server_async.py
@@ -9,6 +9,7 @@ usage::
                     [--framer {ascii,rtu,socket,tls}]
                     [--log {critical,error,warning,info,debug}]
                     [--port PORT]
+                    [--baudrate BAUDRATE]
                     [--device_ids DEVICE_IDS]
 
     -h, --help
@@ -21,6 +22,7 @@ usage::
         set log level, default is info
     -p, --port PORT
         set port
+    --baudrate BAUDRATE
         set serial device baud rate
     --device_ids DEVICE IDs
         set list of devices to respond to

--- a/examples/server_sync.py
+++ b/examples/server_sync.py
@@ -9,6 +9,7 @@ usage::
                    [--framer {ascii,rtu,socket,tls}]
                    [--log {critical,error,warning,info,debug}]
                    [--port PORT]
+                   [--baudrate BAUDRATE]
                    [--device_ids DEVICE_IDS]
 
     -h, --help
@@ -21,6 +22,7 @@ usage::
         set log level, default is info
     -p, --port PORT
         set port
+    --baudrate BAUDRATE
         set serial device baud rate
     --device_ids DEVICE_IDS
         set list of devices to respond to

--- a/examples/server_updating.py
+++ b/examples/server_updating.py
@@ -9,6 +9,7 @@ usage::
     server_updating.py [-h]
                        [--log {critical,error,warning,info,debug}]
                        [--port PORT]
+                       [--baudrate BAUDRATE]
                        [--host HOST]
 
     -h, --help
@@ -17,6 +18,7 @@ usage::
         set log level, default is info
     -p, --port PORT
         set port
+    --baudrate BAUDRATE
         set serial device baud rate
     --host HOST
         set HOST


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

The usage text in several examples is missing the option `--baudrate`, even though:
- the option is still available as a CLI argument
- the explanation for this option is still present