### PR TITLE
Fix CSS lookup for simulator server

### DIFF
--- a/pymodbus/server/simulator/http_server.py
+++ b/pymodbus/server/simulator/http_server.py
@@ -171,7 +171,7 @@ class ModbusSimulatorServer:
             [
                 web.get("/api/{tail:[a-z]*}", self.handle_html),
                 web.post("/restapi/{tail:[a-z]*}", self.handle_json),
-                web.get("/{tail:[a-z0-9.]*}", self.handle_html_static),
+                web.get("/{tail:[a-z0-9_.]*}", self.handle_html_static),
                 web.get("/", self.handle_html_static),
             ]
         )


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->

Fix CSS lookup when running `pymodbus.simulator`.

Currently, the pymodbus simulator fails to load CSS:

<details><summary>Before</summary>
<p>

<img width="2032" height="1162" alt="pymodbus_simulator_before" src="https://github.com/user-attachments/assets/d337fe86-2d4f-4ce4-8c47-10d591df2010" />

</p>
</details> 

With this change, I observe CSS loading:

<details><summary>After</summary>
<p>

<img width="2032" height="1162" alt="pymodbus_simulator_after" src="https://github.com/user-attachments/assets/964c34e4-6da1-4377-8f8d-bbbc537ecbaa" />

</p>
</details>

## Background

I can confirm that I observed a 404 on the `pymodbus_styles.css`:
```
pymodbus_styles.css:1  Failed to load resource: the server responded with a status of 404 (Not Found)
pymodbus_styles.css:1  Failed to load resource: the server responded with a status of 404 (Not Found)
```

in both Chrome and Firefox.

I suspect that this regex will only serve files that contain the characters:
- `a-z` (lowercase letters)
- `0-9` (digits)
- `.` (any number of)

I did confirm that an alternative solution would work:
- rename all `pymodbus_styles.css` references to `pymodbusstyles.css`
- rename the file itself to `pymodbusstyles.css`

This removes the `_`, allowing the existing regex to work. However, I proposed what I feel is a more light-weight solution: extending the regex.