### PR TITLE
Harden ASCII framer.

### DIFF
--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -52,9 +52,13 @@ class FramerAscii(FramerBase):
                 Log.debug("Incomplete frame: {} wait for more data", data, ":hex")
                 return used_len, 0, 0, self.EMPTY
             dev_id = int(buffer[1:3], 16)
-            lrc = int(buffer[end - 2: end], 16)
-            msg = a2b_hex(buffer[1 : end - 2])
             used_len += end + 2
+            try:
+                lrc = int(buffer[end - 2: end], 16)
+                msg = a2b_hex(buffer[1 : end - 2])
+            except:
+                Log.debug("Frame cannot be converted to hex: {} skipping", data, ":hex")
+                return used_len, dev_id, 0, self.EMPTY
             if not self.check_LRC(msg, lrc):
                 Log.debug("LRC wrong in frame: {} skipping", data, ":hex")
                 continue

--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -56,7 +56,7 @@ class FramerAscii(FramerBase):
             try:
                 lrc = int(buffer[end - 2: end], 16)
                 msg = a2b_hex(buffer[1 : end - 2])
-            except:
+            except:  # pylint: disable=bare-except
                 Log.debug("Frame cannot be converted to hex: {} skipping", data, ":hex")
                 return used_len, dev_id, 0, self.EMPTY
             if not self.check_LRC(msg, lrc):

--- a/pymodbus/framer/ascii.py
+++ b/pymodbus/framer/ascii.py
@@ -56,7 +56,7 @@ class FramerAscii(FramerBase):
             try:
                 lrc = int(buffer[end - 2: end], 16)
                 msg = a2b_hex(buffer[1 : end - 2])
-            except:  # pylint: disable=bare-except
+            except ValueError:
                 Log.debug("Frame cannot be converted to hex: {} skipping", data, ":hex")
                 return used_len, dev_id, 0, self.EMPTY
             if not self.check_LRC(msg, lrc):

--- a/test/framer/test_framer.py
+++ b/test/framer/test_framer.py
@@ -77,11 +77,6 @@ class TestFramer:
         assert used_len == len(msg)
         assert pdu
 
-    async def test_multidrop_timing(self):
-        """Test bz_bps=."""
-        # assert FramerRTU(DecodePDU(True), multidrop = (8, 2, 9600, []))
-        # assert FramerRTU(DecodePDU(True), multidrop = (8, 2, 38400, []))
-
 class TestFramerType:
     """Test classes."""
 
@@ -493,3 +488,18 @@ class TestFramerType:
         assert dev_id == 0
         assert tid == 0
         assert pdu == framer.EMPTY
+
+    @pytest.mark.parametrize(("entry"), [FramerType.ASCII])
+    @pytest.mark.parametrize(("is_server"), [False, True])
+    @pytest.mark.parametrize(("msg"), [
+        (b':0107F\r\n'),
+        (b':0107FG\r\n'),
+    ])
+    def test_framer_ascii_decode(self, test_framer, msg):
+        """Test a tcp frame transaction."""
+        used_len, pdu = test_framer.handleFrame(msg, 1, 0)
+        assert not used_len
+        assert not pdu
+        used_len, pdu = test_framer.handleFrame(msg + b':0003007C00027F\r\n', 1, 0)
+        assert used_len >= 8
+        assert not pdu


### PR DESCRIPTION
<!--  Please raise your PR's against the `dev` branch instead of `master` -->
fixes #2917 

Remark any framer (apart from the TLS framer) is NON SECURE, and was never meant to be !!! when used on tcp/ip or UDP they should be used within a VPN or similar secure transport.

However with RTU and ASCII framers, bit error can occur on the rs485, and of course the framer should gracefully handle that.

Added a specific test case with the examples from #2917